### PR TITLE
Save execution history in workspace metada

### DIFF
--- a/bundles/fr.kazejiyu.ekumi.core/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/fr.kazejiyu.ekumi.core/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,7 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/bundles/fr.kazejiyu.ekumi.core/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.ekumi.core/META-INF/MANIFEST.MF
@@ -7,7 +7,8 @@ Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package: fr.kazejiyu.ekumi.core.activities,
+Export-Package: fr.kazejiyu.ekumi.core,
+ fr.kazejiyu.ekumi.core.activities,
  fr.kazejiyu.ekumi.core.activities.impl,
  fr.kazejiyu.ekumi.core.datatypes,
  fr.kazejiyu.ekumi.core.datatypes.exceptions,
@@ -28,3 +29,4 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources;bundle-version="3.12.0"
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: fr.kazejiyu.ekumi.core
+Bundle-Activator: fr.kazejiyu.ekumi.core.EKumiPlugin

--- a/bundles/fr.kazejiyu.ekumi.core/model/ekumi.aird
+++ b/bundles/fr.kazejiyu.ekumi.core/model/ekumi.aird
@@ -60,6 +60,15 @@
             <labelColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='dark_blue']"/>
           </endLabelStyleDescription>
         </computedStyleDescriptions>
+        <computedStyleDescriptions xmi:type="style:EdgeStyleDescription" xmi:id="_N2l6AK5WEeiEHriEyv60bw" sourceArrow="InputArrow" targetArrow="FillDiamond" routingStyle="manhattan">
+          <strokeColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+          <beginLabelStyleDescription xmi:type="style:BeginLabelStyleDescription" xmi:id="_N2l6Aa5WEeiEHriEyv60bw" showIcon="false" labelExpression="service:renderEOpposite">
+            <labelColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+          </beginLabelStyleDescription>
+          <endLabelStyleDescription xmi:type="style:EndLabelStyleDescription" xmi:id="_N2l6Aq5WEeiEHriEyv60bw" showIcon="false" labelExpression="service:render">
+            <labelColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+          </endLabelStyleDescription>
+        </computedStyleDescriptions>
       </data>
     </ownedAnnotationEntries>
     <ownedAnnotationEntries xmi:type="description:AnnotationEntry" xmi:id="_VCNtRhjnEeiuId3O6nWhBA" source="GMF_DIAGRAMS">
@@ -1138,21 +1147,21 @@
           <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YHbkYKk3EeiYF63zlN9bRg" id="(0.5,0.5)"/>
           <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_YHbkYak3EeiYF63zlN9bRg" id="(0.5,0.5)"/>
         </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_bKi94K1aEeiW7ukDnY6yYw" type="4001" element="_bJzXAK1aEeiW7ukDnY6yYw" source="_XHWDoK1ZEeiW7ukDnY6yYw" target="_zM9tQBjqEeiuId3O6nWhBA">
-          <children xmi:type="notation:Node" xmi:id="_bKlaIK1aEeiW7ukDnY6yYw" type="6001">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bKlaIa1aEeiW7ukDnY6yYw" x="-35" y="8"/>
+        <edges xmi:type="notation:Edge" xmi:id="_RUlEUK-JEeipa5jvvwO07A" type="4001" element="_RTs6kK-JEeipa5jvvwO07A" source="_XHWDoK1ZEeiW7ukDnY6yYw" target="_zM9tQBjqEeiuId3O6nWhBA">
+          <children xmi:type="notation:Node" xmi:id="_RVCXUK-JEeipa5jvvwO07A" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RVCXUa-JEeipa5jvvwO07A" y="-10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_bKmBMK1aEeiW7ukDnY6yYw" type="6002">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bKmBMa1aEeiW7ukDnY6yYw" x="6" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_RVCXUq-JEeipa5jvvwO07A" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RVCXU6-JEeipa5jvvwO07A" y="10"/>
           </children>
-          <children xmi:type="notation:Node" xmi:id="_bKmoQK1aEeiW7ukDnY6yYw" type="6003">
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bKmoQa1aEeiW7ukDnY6yYw" x="-7" y="10"/>
+          <children xmi:type="notation:Node" xmi:id="_RVEzkK-JEeipa5jvvwO07A" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_RVEzka-JEeipa5jvvwO07A" y="10"/>
           </children>
-          <styles xmi:type="notation:ConnectorStyle" xmi:id="_bKi94a1aEeiW7ukDnY6yYw" routing="Rectilinear"/>
-          <styles xmi:type="notation:FontStyle" xmi:id="_bKi94q1aEeiW7ukDnY6yYw" fontColor="7490599" fontName="Segoe UI" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bKi9461aEeiW7ukDnY6yYw" points="[-20, 0, -110, 125]$[-20, -60, -110, 65]$[90, -60, 0, 65]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bKxAUK1aEeiW7ukDnY6yYw" id="(0.5932203389830508,0.0)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bKxAUa1aEeiW7ukDnY6yYw" id="(0.0,0.15306122448979592)"/>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_RUlEUa-JEeipa5jvvwO07A" routing="Rectilinear"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_RUlEUq-JEeipa5jvvwO07A" fontColor="7490599" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_RUlEU6-JEeipa5jvvwO07A" points="[0, 0, -70, 125]$[0, -125, -70, 0]$[70, -125, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RVEzkq-JEeipa5jvvwO07A" id="(0.7627118644067796,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_RVEzk6-JEeipa5jvvwO07A" id="(0.0,0.15306122448979592)"/>
         </edges>
       </data>
     </ownedAnnotationEntries>
@@ -1247,7 +1256,7 @@
       </ownedStyle>
       <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_zMvq0BjqEeiuId3O6nWhBA" name="Variable" tooltipText="" incomingEdges="_Ci25MBjrEeiuId3O6nWhBA _TRmHYBjrEeiuId3O6nWhBA _XvM7IBjrEeiuId3O6nWhBA _Tu7goFYVEeipQ9goERh_7A _CHdLQFYjEeipQ9goERh_7A _JkQ7EFYjEeipQ9goERh_7A _YF8MQFZZEeipQ9goERh_7A _d4cWYFZZEeipQ9goERh_7A _pSJLoKkxEeiWC-D71O9BLw _bJzXAK1aEeiW7ukDnY6yYw" width="12" height="10">
+    <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_zMvq0BjqEeiuId3O6nWhBA" name="Variable" tooltipText="" incomingEdges="_Ci25MBjrEeiuId3O6nWhBA _TRmHYBjrEeiuId3O6nWhBA _XvM7IBjrEeiuId3O6nWhBA _Tu7goFYVEeipQ9goERh_7A _CHdLQFYjEeipQ9goERh_7A _JkQ7EFYjEeipQ9goERh_7A _YF8MQFZZEeipQ9goERh_7A _d4cWYFZZEeipQ9goERh_7A _pSJLoKkxEeiWC-D71O9BLw _RTs6kK-JEeipa5jvvwO07A" width="12" height="10">
       <target xmi:type="ecore:EClass" href="ekumi.ecore#//Variable"/>
       <semanticElements xmi:type="ecore:EClass" href="ekumi.ecore#//Variable"/>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
@@ -1736,9 +1745,8 @@
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
       <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
       <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-      <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_pvH2EK1kEeiW7ukDnY6yYw" iconPath="/org.eclipse.emf.ecoretools.design/icons/full/obj16/EClass_abstract.gif" borderSize="1" borderSizeComputationExpression="1" borderColor="125,125,125" backgroundStyle="Liquid" foregroundColor="228,228,228">
-        <labelFormat>italic</labelFormat>
-        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@conditionnalStyles.1/@style"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_Y6YNgK-IEeipa5jvvwO07A" borderSize="1" borderSizeComputationExpression="1" backgroundStyle="Liquid" foregroundColor="255,252,216">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']"/>
       <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_K-2n0K1ZEeiW7ukDnY6yYw" name="events : Events" tooltipText="">
@@ -2189,10 +2197,9 @@
       <target xmi:type="ecore:EReference" href="ekumi.ecore#//UnsafeContext/execution"/>
       <semanticElements xmi:type="ecore:EReference" href="ekumi.ecore#//Execution/context"/>
       <semanticElements xmi:type="ecore:EReference" href="ekumi.ecore#//UnsafeContext/execution"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_YGoTIKk3EeiYF63zlN9bRg" sourceArrow="InputArrow" routingStyle="manhattan" strokeColor="0,0,0">
-        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='Bi-directional%20EC_EReference%20']/@style"/>
-        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" xmi:id="_YGoTIak3EeiYF63zlN9bRg" showIcon="false"/>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_YGoTIqk3EeiYF63zlN9bRg" showIcon="false"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_N2mhEK5WEeiEHriEyv60bw" description="_N2l6AK5WEeiEHriEyv60bw" sourceArrow="InputArrow" targetArrow="FillDiamond" routingStyle="manhattan" strokeColor="0,0,0">
+        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" xmi:id="_N2mhEa5WEeiEHriEyv60bw" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_N2mhEq5WEeiEHriEyv60bw" showIcon="false"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='Bi-directional%20EC_EReference%20']"/>
     </ownedDiagramElements>
@@ -2256,12 +2263,11 @@
         <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EDataType']/@subNodeMappings[name='EC_DataType_InstanceClassName']"/>
       </ownedElements>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_XHAscK1ZEeiW7ukDnY6yYw" name="Context" tooltipText="" outgoingEdges="_bJzXAK1aEeiW7ukDnY6yYw" width="12" height="10">
+    <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_XHAscK1ZEeiW7ukDnY6yYw" name="Context" tooltipText="" outgoingEdges="_RTs6kK-JEeipa5jvvwO07A" width="12" height="10">
       <target xmi:type="ecore:EClass" href="ekumi.ecore#//Context"/>
       <semanticElements xmi:type="ecore:EClass" href="ekumi.ecore#//Context"/>
-      <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_XHAsca1ZEeiW7ukDnY6yYw" iconPath="/org.eclipse.emf.ecoretools.design/icons/full/obj16/EClass_abstract.gif" borderSize="1" borderSizeComputationExpression="1" borderColor="125,125,125" backgroundStyle="Liquid" foregroundColor="228,228,228">
-        <labelFormat>italic</labelFormat>
-        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@conditionnalStyles.1/@style"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_3av_kK-IEeipa5jvvwO07A" borderSize="1" borderSizeComputationExpression="1" backgroundStyle="Liquid" foregroundColor="255,252,216">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']"/>
       <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_X_6DUK1ZEeiW7ukDnY6yYw" name="events() : Events" tooltipText="events() : Events">
@@ -2281,12 +2287,12 @@
         <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='Operation']"/>
       </ownedElements>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_bJzXAK1aEeiW7ukDnY6yYw" name="[0..*] /variables" sourceNode="_XHAscK1ZEeiW7ukDnY6yYw" targetNode="_zMvq0BjqEeiuId3O6nWhBA">
+    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_RTs6kK-JEeipa5jvvwO07A" name="[0..*] /variables" sourceNode="_XHAscK1ZEeiW7ukDnY6yYw" targetNode="_zMvq0BjqEeiuId3O6nWhBA">
       <target xmi:type="ecore:EReference" href="ekumi.ecore#//Context/variables"/>
       <semanticElements xmi:type="ecore:EReference" href="ekumi.ecore#//Context/variables"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_cTmQoK1aEeiW7ukDnY6yYw" description="_PMAIAFYVEeipQ9goERh_7A" routingStyle="manhattan" strokeColor="114,159,207">
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_cTmQoa1aEeiW7ukDnY6yYw" showIcon="false" labelColor="39,76,114"/>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_cTmQoq1aEeiW7ukDnY6yYw" labelSize="6" showIcon="false" labelColor="39,76,114"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_Tb1rwK-JEeipa5jvvwO07A" description="_PMAIAFYVEeipQ9goERh_7A" routingStyle="manhattan" strokeColor="114,159,207">
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_Tb1rwa-JEeipa5jvvwO07A" showIcon="false" labelColor="39,76,114"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_Tb1rwq-JEeipa5jvvwO07A" labelSize="6" showIcon="false" labelColor="39,76,114"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC_EReference']"/>
     </ownedDiagramElements>

--- a/bundles/fr.kazejiyu.ekumi.core/model/ekumi.ecore
+++ b/bundles/fr.kazejiyu.ekumi.core/model/ekumi.ecore
@@ -26,7 +26,7 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="root" eType="#//Activity"
         containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="activities" upperBound="-1"
-        eType="#//Activity" changeable="false" volatile="true" unsettable="true" derived="true"/>
+        eType="#//Activity" changeable="false" volatile="true" transient="true" derived="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="MultipleInstances" eSuperTypes="#//Activity"/>
   <eClassifiers xsi:type="ecore:EClass" name="DataFlow">
@@ -40,7 +40,7 @@
       </eAnnotations>
     </eStructuralFeatures>
     <eStructuralFeatures xsi:type="ecore:EReference" name="source" eType="#//Activity"
-        changeable="false" volatile="true" unsettable="true" derived="true">
+        changeable="false" volatile="true" derived="true">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="get" value="return input.getOwner();"/>
       </eAnnotations>
@@ -118,14 +118,16 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="activity" eType="#//Activity"
         containment="true"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="UnsafeContext" abstract="true">
+  <eClassifiers xsi:type="ecore:EClass" name="UnsafeContext">
     <eOperations name="safe" eType="#//Context"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="variables" upperBound="-1"
         eType="#//Variable" derived="true" containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="execution" eType="#//Execution"
         eOpposite="#//Execution/context"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="events" eType="#//Events"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="executionStatus" eType="#//ExecutionStatus"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="events" eType="#//Events"
+        transient="true"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="executionStatus" eType="#//ExecutionStatus"
+        transient="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Serializable" abstract="true" interface="true"/>
   <eClassifiers xsi:type="ecore:EClass" name="DataFlows">
@@ -146,9 +148,11 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="activity" eType="#//Activity"
         containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="context" eType="#//UnsafeContext"
-        eOpposite="#//UnsafeContext/execution"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="startDate" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EDate"
-        changeable="false" unsettable="true"/>
+        containment="true" eOpposite="#//UnsafeContext/execution"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="startDate" unique="false"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EDate">
+      <eAnnotations/>
+    </eStructuralFeatures>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="ListOfVariables" eSuperTypes="#//Variable">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="size" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt"
@@ -171,10 +175,10 @@
   <eClassifiers xsi:type="ecore:EDataType" name="Events" instanceClassName="fr.kazejiyu.ekumi.core.execution.events.Events"/>
   <eClassifiers xsi:type="ecore:EDataType" name="InterruptedExecutionException" instanceClassName="fr.kazejiyu.ekumi.core.exceptions.InterruptedExecutionException"/>
   <eClassifiers xsi:type="ecore:EDataType" name="ExecutionStatus" instanceClassName="fr.kazejiyu.ekumi.core.execution.ExecutionStatus"/>
-  <eClassifiers xsi:type="ecore:EClass" name="Context" abstract="true">
+  <eClassifiers xsi:type="ecore:EClass" name="Context">
     <eOperations name="events" eType="#//Events"/>
     <eOperations name="execution" eType="#//ExecutionStatus"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="variables" upperBound="-1"
-        eType="#//Variable" derived="true"/>
+        eType="#//Variable" transient="true" derived="true"/>
   </eClassifiers>
 </ecore:EPackage>

--- a/bundles/fr.kazejiyu.ekumi.core/model/ekumi.genmodel
+++ b/bundles/fr.kazejiyu.ekumi.core/model/ekumi.genmodel
@@ -112,7 +112,7 @@
     </genClasses>
     <genClasses ecoreClass="ekumi.ecore#//Execution">
       <genFeatures children="true" createChild="true" propertySortChoices="true" ecoreFeature="ecore:EReference ekumi.ecore#//Execution/activity"/>
-      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference ekumi.ecore#//Execution/context"/>
+      <genFeatures children="true" createChild="true" propertySortChoices="true" ecoreFeature="ecore:EReference ekumi.ecore#//Execution/context"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute ekumi.ecore#//Execution/startDate"/>
       <genOperations ecoreOperation="ekumi.ecore#//Execution/start"/>
       <genOperations ecoreOperation="ekumi.ecore#//Execution/join"/>

--- a/bundles/fr.kazejiyu.ekumi.core/src-gen/fr/kazejiyu/ekumi/core/EKumiPlugin.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src-gen/fr/kazejiyu/ekumi/core/EKumiPlugin.java
@@ -1,0 +1,71 @@
+package fr.kazejiyu.ekumi.core;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.emf.common.util.URI;
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+
+import fr.kazejiyu.ekumi.core.exceptions.EKumiRuntimeException;
+
+/**
+ * Activator of the {@code fr.kazejiyu.ekumi.core} bundle.
+ * 
+ * @author Emmanuel CHEBBI
+ */
+public class EKumiPlugin implements BundleActivator {
+	
+	public static final String ID = "fr.kazejiyu.ekumi.core";
+	
+	private static final URI STATE_LOCATION_URI = URI.createURI("platform:/meta/" + ID + "/");
+
+	// The shared instance
+	private static EKumiPlugin plugin;
+
+	@Override
+	public void start(BundleContext context) throws Exception {
+		plugin = this;
+	}
+
+	@Override
+	public void stop(BundleContext context) throws Exception {
+		plugin = null;
+	}
+
+	/**
+	 * Returns the shared instance
+	 *
+	 * @return the shared instance
+	 */
+	public static EKumiPlugin getDefault() {
+		return plugin;
+	}
+	
+	/**
+	 * Returns the URI of the state directory for this bundle under <i>.metadata/.plugins/</i>.
+	 * @return the URI of the state directory for this bundle under <i>.metadata/.plugins/</i>
+	 */
+	public static URI getStateLocationURI() {
+		return STATE_LOCATION_URI;
+	}
+	
+	/**
+	 * Returns the location of the state directory for this bundle under <i>.metadata/.plugins/</i>.
+	 * @return the location of the state directory for this bundle under <i>.metadata/.plugins/</i>
+	 */
+	public static Path getStateLocation() {
+		try {
+			return Paths.get(FileLocator.resolve(new URL(getStateLocationURI().toString())).toURI());
+			
+		} catch (URISyntaxException | IOException e) {
+			// Should never happen
+			throw new EKumiRuntimeException("An unexpected error occurred while resolving the state location of " + ID, e);
+		}
+	}
+
+}

--- a/bundles/fr.kazejiyu.ekumi.core/src-gen/fr/kazejiyu/ekumi/core/ekumi/Context.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src-gen/fr/kazejiyu/ekumi/core/ekumi/Context.java
@@ -22,7 +22,7 @@ import fr.kazejiyu.ekumi.core.execution.events.Events;
  * </ul>
  *
  * @see fr.kazejiyu.ekumi.core.ekumi.EkumiPackage#getContext()
- * @model abstract="true"
+ * @model
  * @generated
  */
 public interface Context extends EObject {
@@ -34,7 +34,7 @@ public interface Context extends EObject {
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Variables</em>' reference list.
 	 * @see fr.kazejiyu.ekumi.core.ekumi.EkumiPackage#getContext_Variables()
-	 * @model derived="true"
+	 * @model transient="true" derived="true"
 	 * @generated
 	 */
 	EList<Variable> getVariables();

--- a/bundles/fr.kazejiyu.ekumi.core/src-gen/fr/kazejiyu/ekumi/core/ekumi/DataFlow.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src-gen/fr/kazejiyu/ekumi/core/ekumi/DataFlow.java
@@ -96,22 +96,11 @@ public interface DataFlow extends EObject {
 	 * Returns the value of the '<em><b>Source</b></em>' reference.
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Source</em>' reference.
-	 * @see #isSetSource()
 	 * @see fr.kazejiyu.ekumi.core.ekumi.EkumiPackage#getDataFlow_Source()
-	 * @model unsettable="true" changeable="false" volatile="true" derived="true"
+	 * @model changeable="false" volatile="true" derived="true"
 	 *        annotation="http://www.eclipse.org/emf/2002/GenModel get='return input.getOwner();'"
 	 * @generated
 	 */
 	Activity getSource();
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * Returns whether the value of the '{@link fr.kazejiyu.ekumi.core.ekumi.DataFlow#getSource <em>Source</em>}' reference is set.
-	 * <!-- end-user-doc -->
-	 * @return whether the value of the '<em>Source</em>' reference is set.
-	 * @see #getSource()
-	 * @generated
-	 */
-	boolean isSetSource();
 
 } // DataFlow

--- a/bundles/fr.kazejiyu.ekumi.core/src-gen/fr/kazejiyu/ekumi/core/ekumi/EkumiFactory.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src-gen/fr/kazejiyu/ekumi/core/ekumi/EkumiFactory.java
@@ -95,6 +95,15 @@ public interface EkumiFactory extends EFactory {
 
 	/**
 	 * <!-- begin-user-doc -->
+	 * Returns a new instance of class '<em>Unsafe Context</em>'.
+	 * <!-- end-user-doc -->
+	 * @return a new instance of class '<em>Unsafe Context</em>'.
+	 * @generated
+	 */
+	UnsafeContext createUnsafeContext();
+
+	/**
+	 * <!-- begin-user-doc -->
 	 * Returns a new instance of class '<em>Data Flows</em>'.
 	 * <!-- end-user-doc -->
 	 * @return a new instance of class '<em>Data Flows</em>'.
@@ -146,6 +155,15 @@ public interface EkumiFactory extends EFactory {
 	 * @generated
 	 */
 	ParallelSplit createParallelSplit();
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * Returns a new instance of class '<em>Context</em>'.
+	 * <!-- end-user-doc -->
+	 * @return a new instance of class '<em>Context</em>'.
+	 * @generated
+	 */
+	Context createContext();
 
 	/**
 	 * <!-- begin-user-doc -->

--- a/bundles/fr.kazejiyu.ekumi.core/src-gen/fr/kazejiyu/ekumi/core/ekumi/EkumiPackage.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src-gen/fr/kazejiyu/ekumi/core/ekumi/EkumiPackage.java
@@ -1271,7 +1271,7 @@ public interface EkumiPackage extends EPackage {
 	int UNSAFE_CONTEXT__VARIABLES = 0;
 
 	/**
-	 * The feature id for the '<em><b>Execution</b></em>' reference.
+	 * The feature id for the '<em><b>Execution</b></em>' container reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
@@ -1446,7 +1446,7 @@ public interface EkumiPackage extends EPackage {
 	int EXECUTION__ACTIVITY = 0;
 
 	/**
-	 * The feature id for the '<em><b>Context</b></em>' reference.
+	 * The feature id for the '<em><b>Context</b></em>' containment reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
@@ -2597,10 +2597,10 @@ public interface EkumiPackage extends EPackage {
 	EReference getUnsafeContext_Variables();
 
 	/**
-	 * Returns the meta object for the reference '{@link fr.kazejiyu.ekumi.core.ekumi.UnsafeContext#getExecution <em>Execution</em>}'.
+	 * Returns the meta object for the container reference '{@link fr.kazejiyu.ekumi.core.ekumi.UnsafeContext#getExecution <em>Execution</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @return the meta object for the reference '<em>Execution</em>'.
+	 * @return the meta object for the container reference '<em>Execution</em>'.
 	 * @see fr.kazejiyu.ekumi.core.ekumi.UnsafeContext#getExecution()
 	 * @see #getUnsafeContext()
 	 * @generated
@@ -2765,10 +2765,10 @@ public interface EkumiPackage extends EPackage {
 	EReference getExecution_Activity();
 
 	/**
-	 * Returns the meta object for the reference '{@link fr.kazejiyu.ekumi.core.ekumi.Execution#getContext <em>Context</em>}'.
+	 * Returns the meta object for the containment reference '{@link fr.kazejiyu.ekumi.core.ekumi.Execution#getContext <em>Context</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @return the meta object for the reference '<em>Context</em>'.
+	 * @return the meta object for the containment reference '<em>Context</em>'.
 	 * @see fr.kazejiyu.ekumi.core.ekumi.Execution#getContext()
 	 * @see #getExecution()
 	 * @generated
@@ -3445,7 +3445,7 @@ public interface EkumiPackage extends EPackage {
 		EReference UNSAFE_CONTEXT__VARIABLES = eINSTANCE.getUnsafeContext_Variables();
 
 		/**
-		 * The meta object literal for the '<em><b>Execution</b></em>' reference feature.
+		 * The meta object literal for the '<em><b>Execution</b></em>' container reference feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
 		 * @generated
@@ -3581,7 +3581,7 @@ public interface EkumiPackage extends EPackage {
 		EReference EXECUTION__ACTIVITY = eINSTANCE.getExecution_Activity();
 
 		/**
-		 * The meta object literal for the '<em><b>Context</b></em>' reference feature.
+		 * The meta object literal for the '<em><b>Context</b></em>' containment reference feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
 		 * @generated

--- a/bundles/fr.kazejiyu.ekumi.core/src-gen/fr/kazejiyu/ekumi/core/ekumi/Execution.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src-gen/fr/kazejiyu/ekumi/core/ekumi/Execution.java
@@ -51,11 +51,11 @@ public interface Execution extends EObject {
 	 * <!-- begin-user-doc -->
 	 * Returns the value of the '<em><b>Context</b></em>' reference.
 	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Context</em>' reference.
+	 * @return the value of the '<em>Context</em>' containment reference.
 	 * @see #setContext(UnsafeContext)
 	 * @see fr.kazejiyu.ekumi.core.ekumi.EkumiPackage#getExecution_Context()
 	 * @see fr.kazejiyu.ekumi.core.ekumi.UnsafeContext#getExecution
-	 * @model opposite="execution"
+	 * @model opposite="execution" containment="true"
 	 * @generated
 	 */
 	UnsafeContext getContext();
@@ -64,7 +64,7 @@ public interface Execution extends EObject {
 	 * <!-- begin-user-doc -->
 	 * Sets the value of the '{@link fr.kazejiyu.ekumi.core.ekumi.Execution#getContext <em>Context</em>}' reference.
 	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Context</em>' reference.
+	 * @param value the new value of the '<em>Context</em>' containment reference.
 	 * @see #getContext()
 	 * @generated
 	 */
@@ -75,22 +75,22 @@ public interface Execution extends EObject {
 	 * Returns the value of the '<em><b>Start Date</b></em>' attribute.
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Start Date</em>' attribute.
-	 * @see #isSetStartDate()
+	 * @see #setStartDate(Date)
 	 * @see fr.kazejiyu.ekumi.core.ekumi.EkumiPackage#getExecution_StartDate()
-	 * @model unsettable="true" changeable="false"
+	 * @model unique="false"
 	 * @generated
 	 */
 	Date getStartDate();
 
 	/**
 	 * <!-- begin-user-doc -->
-	 * Returns whether the value of the '{@link fr.kazejiyu.ekumi.core.ekumi.Execution#getStartDate <em>Start Date</em>}' attribute is set.
+	 * Sets the value of the '{@link fr.kazejiyu.ekumi.core.ekumi.Execution#getStartDate <em>Start Date</em>}' attribute.
 	 * <!-- end-user-doc -->
-	 * @return whether the value of the '<em>Start Date</em>' attribute is set.
+	 * @param value the new value of the '<em>Start Date</em>' attribute.
 	 * @see #getStartDate()
 	 * @generated
 	 */
-	boolean isSetStartDate();
+	void setStartDate(Date value);
 
 	/**
 	 * <!-- begin-user-doc -->

--- a/bundles/fr.kazejiyu.ekumi.core/src-gen/fr/kazejiyu/ekumi/core/ekumi/Sequence.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src-gen/fr/kazejiyu/ekumi/core/ekumi/Sequence.java
@@ -53,21 +53,10 @@ public interface Sequence extends Activity {
 	 * The list contents are of type {@link fr.kazejiyu.ekumi.core.ekumi.Activity}.
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Activities</em>' reference list.
-	 * @see #isSetActivities()
 	 * @see fr.kazejiyu.ekumi.core.ekumi.EkumiPackage#getSequence_Activities()
-	 * @model unsettable="true" changeable="false" volatile="true" derived="true"
+	 * @model transient="true" changeable="false" volatile="true" derived="true"
 	 * @generated
 	 */
 	EList<Activity> getActivities();
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * Returns whether the value of the '{@link fr.kazejiyu.ekumi.core.ekumi.Sequence#getActivities <em>Activities</em>}' reference list is set.
-	 * <!-- end-user-doc -->
-	 * @return whether the value of the '<em>Activities</em>' reference list is set.
-	 * @see #getActivities()
-	 * @generated
-	 */
-	boolean isSetActivities();
 
 } // Sequence

--- a/bundles/fr.kazejiyu.ekumi.core/src-gen/fr/kazejiyu/ekumi/core/ekumi/UnsafeContext.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src-gen/fr/kazejiyu/ekumi/core/ekumi/UnsafeContext.java
@@ -26,7 +26,7 @@ import org.eclipse.emf.ecore.EObject;
  * </ul>
  *
  * @see fr.kazejiyu.ekumi.core.ekumi.EkumiPackage#getUnsafeContext()
- * @model abstract="true"
+ * @model
  * @generated
  */
 public interface UnsafeContext extends EObject {
@@ -47,11 +47,11 @@ public interface UnsafeContext extends EObject {
 	 * Returns the value of the '<em><b>Execution</b></em>' reference.
 	 * It is bidirectional and its opposite is '{@link fr.kazejiyu.ekumi.core.ekumi.Execution#getContext <em>Context</em>}'.
 	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Execution</em>' reference.
+	 * @return the value of the '<em>Execution</em>' container reference.
 	 * @see #setExecution(Execution)
 	 * @see fr.kazejiyu.ekumi.core.ekumi.EkumiPackage#getUnsafeContext_Execution()
 	 * @see fr.kazejiyu.ekumi.core.ekumi.Execution#getContext
-	 * @model opposite="context"
+	 * @model opposite="context" transient="false"
 	 * @generated
 	 */
 	Execution getExecution();
@@ -60,7 +60,7 @@ public interface UnsafeContext extends EObject {
 	 * <!-- begin-user-doc -->
 	 * Sets the value of the '{@link fr.kazejiyu.ekumi.core.ekumi.UnsafeContext#getExecution <em>Execution</em>}' reference.
 	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Execution</em>' reference.
+	 * @param value the new value of the '<em>Execution</em>' container reference.
 	 * @see #getExecution()
 	 * @generated
 	 */
@@ -73,7 +73,7 @@ public interface UnsafeContext extends EObject {
 	 * @return the value of the '<em>Events</em>' attribute.
 	 * @see #setEvents(Events)
 	 * @see fr.kazejiyu.ekumi.core.ekumi.EkumiPackage#getUnsafeContext_Events()
-	 * @model dataType="fr.kazejiyu.ekumi.core.ekumi.Events"
+	 * @model dataType="fr.kazejiyu.ekumi.core.ekumi.Events" transient="true"
 	 * @generated
 	 */
 	Events getEvents();
@@ -95,7 +95,7 @@ public interface UnsafeContext extends EObject {
 	 * @return the value of the '<em>Execution Status</em>' attribute.
 	 * @see #setExecutionStatus(ExecutionStatus)
 	 * @see fr.kazejiyu.ekumi.core.ekumi.EkumiPackage#getUnsafeContext_ExecutionStatus()
-	 * @model dataType="fr.kazejiyu.ekumi.core.ekumi.ExecutionStatus"
+	 * @model dataType="fr.kazejiyu.ekumi.core.ekumi.ExecutionStatus" transient="true"
 	 * @generated
 	 */
 	ExecutionStatus getExecutionStatus();

--- a/bundles/fr.kazejiyu.ekumi.core/src-gen/fr/kazejiyu/ekumi/core/ekumi/impl/ContextImpl.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src-gen/fr/kazejiyu/ekumi/core/ekumi/impl/ContextImpl.java
@@ -31,7 +31,7 @@ import fr.kazejiyu.ekumi.core.execution.events.Events;
  *
  * @generated
  */
-public abstract class ContextImpl extends MinimalEObjectImpl.Container implements Context {
+public class ContextImpl extends MinimalEObjectImpl.Container implements Context {
 
 	/**
 	 * The cached value of the '{@link #getVariables() <em>Variables</em>}' reference list.

--- a/bundles/fr.kazejiyu.ekumi.core/src-gen/fr/kazejiyu/ekumi/core/ekumi/impl/DataFlowImpl.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src-gen/fr/kazejiyu/ekumi/core/ekumi/impl/DataFlowImpl.java
@@ -285,7 +285,7 @@ public class DataFlowImpl extends MinimalEObjectImpl.Container implements DataFl
 		case EkumiPackage.DATA_FLOW__DESTINATION:
 			return isSetDestination();
 		case EkumiPackage.DATA_FLOW__SOURCE:
-			return isSetSource();
+			return basicGetSource() != null;
 		}
 		return super.eIsSet(featureID);
 	}

--- a/bundles/fr.kazejiyu.ekumi.core/src-gen/fr/kazejiyu/ekumi/core/ekumi/impl/EkumiFactoryImpl.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src-gen/fr/kazejiyu/ekumi/core/ekumi/impl/EkumiFactoryImpl.java
@@ -79,6 +79,8 @@ public class EkumiFactoryImpl extends EFactoryImpl implements EkumiFactory {
 			return createMultiChoice();
 		case EkumiPackage.BRANCH:
 			return createBranch();
+		case EkumiPackage.UNSAFE_CONTEXT:
+			return createUnsafeContext();
 		case EkumiPackage.DATA_FLOWS:
 			return createDataFlows();
 		case EkumiPackage.EXECUTION:
@@ -91,6 +93,8 @@ public class EkumiFactoryImpl extends EFactoryImpl implements EkumiFactory {
 			return createDriver();
 		case EkumiPackage.PARALLEL_SPLIT:
 			return createParallelSplit();
+		case EkumiPackage.CONTEXT:
+			return createContext();
 		default:
 			throw new IllegalArgumentException("The class '" + eClass.getName() + "' is not a valid classifier");
 		}
@@ -185,6 +189,16 @@ public class EkumiFactoryImpl extends EFactoryImpl implements EkumiFactory {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	public Context createContext() {
+		ContextImpl context = new ContextImpl();
+		return context;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
 	public DataFlow createDataFlow() {
 		DataFlowImpl dataFlow = new DataFlowImpl();
 		return dataFlow;
@@ -238,6 +252,16 @@ public class EkumiFactoryImpl extends EFactoryImpl implements EkumiFactory {
 	public Branch createBranch() {
 		BranchImpl branch = new BranchImpl();
 		return branch;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public UnsafeContext createUnsafeContext() {
+		UnsafeContextImpl unsafeContext = new UnsafeContextImpl();
+		return unsafeContext;
 	}
 
 	/**

--- a/bundles/fr.kazejiyu.ekumi.core/src-gen/fr/kazejiyu/ekumi/core/ekumi/impl/EkumiPackageImpl.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src-gen/fr/kazejiyu/ekumi/core/ekumi/impl/EkumiPackageImpl.java
@@ -1329,7 +1329,7 @@ public class EkumiPackageImpl extends EPackageImpl implements EkumiPackage {
 				!IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED,
 				IS_ORDERED);
 		initEReference(getSequence_Activities(), this.getActivity(), null, "activities", null, 0, -1, Sequence.class,
-				!IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, IS_UNSETTABLE, IS_UNIQUE,
+				IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE,
 				IS_DERIVED, IS_ORDERED);
 
 		initEClass(multipleInstancesEClass, MultipleInstances.class, "MultipleInstances", !IS_ABSTRACT, !IS_INTERFACE,
@@ -1347,8 +1347,8 @@ public class EkumiPackageImpl extends EPackageImpl implements EkumiPackage {
 				!IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, IS_UNSETTABLE, IS_UNIQUE,
 				IS_DERIVED, IS_ORDERED);
 		initEReference(getDataFlow_Source(), this.getActivity(), null, "source", null, 0, 1, DataFlow.class,
-				!IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, IS_UNSETTABLE, IS_UNIQUE,
-				IS_DERIVED, IS_ORDERED);
+				!IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE,
+				IS_UNIQUE, IS_DERIVED, IS_ORDERED);
 
 		initEClass(variableEClass, Variable.class, "Variable", !IS_ABSTRACT, !IS_INTERFACE,
 				IS_GENERATED_INSTANCE_CLASS);
@@ -1422,18 +1422,18 @@ public class EkumiPackageImpl extends EPackageImpl implements EkumiPackage {
 				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE,
 				IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
-		initEClass(unsafeContextEClass, UnsafeContext.class, "UnsafeContext", IS_ABSTRACT, !IS_INTERFACE,
+		initEClass(unsafeContextEClass, UnsafeContext.class, "UnsafeContext", !IS_ABSTRACT, !IS_INTERFACE,
 				IS_GENERATED_INSTANCE_CLASS);
 		initEReference(getUnsafeContext_Variables(), this.getVariable(), null, "variables", null, 0, -1,
 				UnsafeContext.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES,
 				!IS_UNSETTABLE, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
 		initEReference(getUnsafeContext_Execution(), this.getExecution(), this.getExecution_Context(), "execution",
 				null, 0, 1, UnsafeContext.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE,
-				IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+				!IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getUnsafeContext_Events(), this.getEvents(), "events", null, 0, 1, UnsafeContext.class,
-				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+				IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getUnsafeContext_ExecutionStatus(), this.getExecutionStatus(), "executionStatus", null, 0, 1,
-				UnsafeContext.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE,
+				UnsafeContext.class, IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE,
 				!IS_DERIVED, IS_ORDERED);
 
 		initEOperation(getUnsafeContext__Safe(), this.getContext(), "safe", 0, 1, IS_UNIQUE, IS_ORDERED);
@@ -1461,10 +1461,11 @@ public class EkumiPackageImpl extends EPackageImpl implements EkumiPackage {
 				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE,
 				IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEReference(getExecution_Context(), this.getUnsafeContext(), this.getUnsafeContext_Execution(), "context",
-				null, 0, 1, Execution.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE,
-				IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+				null, 0, 1, Execution.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE,
+				!IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getExecution_StartDate(), ecorePackage.getEDate(), "startDate", null, 0, 1, Execution.class,
-				!IS_TRANSIENT, !IS_VOLATILE, !IS_CHANGEABLE, IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, !IS_UNIQUE, !IS_DERIVED,
+				IS_ORDERED);
 
 		initEOperation(getExecution__Start(), null, "start", 0, 1, IS_UNIQUE, IS_ORDERED);
 
@@ -1506,10 +1507,10 @@ public class EkumiPackageImpl extends EPackageImpl implements EkumiPackage {
 				ParallelSplit.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES,
 				!IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
-		initEClass(contextEClass, Context.class, "Context", IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEClass(contextEClass, Context.class, "Context", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEReference(getContext_Variables(), this.getVariable(), null, "variables", null, 0, -1, Context.class,
-				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE,
-				IS_UNIQUE, IS_DERIVED, IS_ORDERED);
+				IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE,
+				IS_DERIVED, IS_ORDERED);
 
 		initEOperation(getContext__Events(), this.getEvents(), "events", 0, 1, IS_UNIQUE, IS_ORDERED);
 
@@ -1540,6 +1541,21 @@ public class EkumiPackageImpl extends EPackageImpl implements EkumiPackage {
 
 		// Create resource
 		createResource(eNS_URI);
+
+		// Create annotations
+		// null
+		createNullAnnotations();
+	}
+
+	/**
+	 * Initializes the annotations for <b>null</b>.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	protected void createNullAnnotations() {
+		String source = null;
+		addAnnotation(getExecution_StartDate(), source, new String[] {});
 	}
 
 } //EkumiPackageImpl

--- a/bundles/fr.kazejiyu.ekumi.core/src-gen/fr/kazejiyu/ekumi/core/ekumi/impl/ExecutionImpl.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src-gen/fr/kazejiyu/ekumi/core/ekumi/impl/ExecutionImpl.java
@@ -47,7 +47,7 @@ public class ExecutionImpl extends MinimalEObjectImpl.Container implements Execu
 	protected Activity activity;
 
 	/**
-	 * The cached value of the '{@link #getContext() <em>Context</em>}' reference.
+	 * The cached value of the '{@link #getContext() <em>Context</em>}' containment reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @see #getContext()
@@ -75,15 +75,6 @@ public class ExecutionImpl extends MinimalEObjectImpl.Container implements Execu
 	 * @ordered
 	 */
 	protected Date startDate = START_DATE_EDEFAULT;
-
-	/**
-	 * This is true if the Start Date attribute has been set.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	protected boolean startDateESet;
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -160,24 +151,6 @@ public class ExecutionImpl extends MinimalEObjectImpl.Container implements Execu
 	 * @generated
 	 */
 	public UnsafeContext getContext() {
-		if (context != null && context.eIsProxy()) {
-			InternalEObject oldContext = (InternalEObject) context;
-			context = (UnsafeContext) eResolveProxy(oldContext);
-			if (context != oldContext) {
-				if (eNotificationRequired())
-					eNotify(new ENotificationImpl(this, Notification.RESOLVE, EkumiPackage.EXECUTION__CONTEXT,
-							oldContext, context));
-			}
-		}
-		return context;
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public UnsafeContext basicGetContext() {
 		return context;
 	}
 
@@ -236,8 +209,12 @@ public class ExecutionImpl extends MinimalEObjectImpl.Container implements Execu
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public boolean isSetStartDate() {
-		return startDateESet;
+	public void setStartDate(Date newStartDate) {
+		Date oldStartDate = startDate;
+		startDate = newStartDate;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, EkumiPackage.EXECUTION__START_DATE, oldStartDate,
+					startDate));
 	}
 
 	/**
@@ -305,8 +282,8 @@ public class ExecutionImpl extends MinimalEObjectImpl.Container implements Execu
 		switch (featureID) {
 		case EkumiPackage.EXECUTION__CONTEXT:
 			if (context != null)
-				msgs = ((InternalEObject) context).eInverseRemove(this, EkumiPackage.UNSAFE_CONTEXT__EXECUTION,
-						UnsafeContext.class, msgs);
+				msgs = ((InternalEObject) context).eInverseRemove(this,
+						EOPPOSITE_FEATURE_BASE - EkumiPackage.EXECUTION__CONTEXT, null, msgs);
 			return basicSetContext((UnsafeContext) otherEnd, msgs);
 		}
 		return super.eInverseAdd(otherEnd, featureID, msgs);
@@ -339,9 +316,7 @@ public class ExecutionImpl extends MinimalEObjectImpl.Container implements Execu
 		case EkumiPackage.EXECUTION__ACTIVITY:
 			return getActivity();
 		case EkumiPackage.EXECUTION__CONTEXT:
-			if (resolve)
-				return getContext();
-			return basicGetContext();
+			return getContext();
 		case EkumiPackage.EXECUTION__START_DATE:
 			return getStartDate();
 		}
@@ -362,6 +337,9 @@ public class ExecutionImpl extends MinimalEObjectImpl.Container implements Execu
 		case EkumiPackage.EXECUTION__CONTEXT:
 			setContext((UnsafeContext) newValue);
 			return;
+		case EkumiPackage.EXECUTION__START_DATE:
+			setStartDate((Date) newValue);
+			return;
 		}
 		super.eSet(featureID, newValue);
 	}
@@ -380,6 +358,9 @@ public class ExecutionImpl extends MinimalEObjectImpl.Container implements Execu
 		case EkumiPackage.EXECUTION__CONTEXT:
 			setContext((UnsafeContext) null);
 			return;
+		case EkumiPackage.EXECUTION__START_DATE:
+			setStartDate(START_DATE_EDEFAULT);
+			return;
 		}
 		super.eUnset(featureID);
 	}
@@ -397,7 +378,7 @@ public class ExecutionImpl extends MinimalEObjectImpl.Container implements Execu
 		case EkumiPackage.EXECUTION__CONTEXT:
 			return context != null;
 		case EkumiPackage.EXECUTION__START_DATE:
-			return isSetStartDate();
+			return START_DATE_EDEFAULT == null ? startDate != null : !START_DATE_EDEFAULT.equals(startDate);
 		}
 		return super.eIsSet(featureID);
 	}
@@ -443,10 +424,7 @@ public class ExecutionImpl extends MinimalEObjectImpl.Container implements Execu
 
 		StringBuffer result = new StringBuffer(super.toString());
 		result.append(" (startDate: ");
-		if (startDateESet)
-			result.append(startDate);
-		else
-			result.append("<unset>");
+		result.append(startDate);
 		result.append(')');
 		return result.toString();
 	}

--- a/bundles/fr.kazejiyu.ekumi.core/src-gen/fr/kazejiyu/ekumi/core/ekumi/impl/SequenceImpl.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src-gen/fr/kazejiyu/ekumi/core/ekumi/impl/SequenceImpl.java
@@ -124,17 +124,6 @@ public class SequenceImpl extends ActivityImpl implements Sequence {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public boolean isSetActivities() {
-		// TODO: implement this method to return whether the 'Activities' reference list is set
-		// Ensure that you remove @generated or mark it @generated NOT
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
 	@Override
 	public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
 		switch (featureID) {
@@ -201,7 +190,7 @@ public class SequenceImpl extends ActivityImpl implements Sequence {
 		case EkumiPackage.SEQUENCE__ROOT:
 			return root != null;
 		case EkumiPackage.SEQUENCE__ACTIVITIES:
-			return isSetActivities();
+			return !getActivities().isEmpty();
 		}
 		return super.eIsSet(featureID);
 	}

--- a/bundles/fr.kazejiyu.ekumi.core/src-gen/fr/kazejiyu/ekumi/core/ekumi/impl/UnsafeContextImpl.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src-gen/fr/kazejiyu/ekumi/core/ekumi/impl/UnsafeContextImpl.java
@@ -28,6 +28,7 @@ import org.eclipse.emf.ecore.impl.ENotificationImpl;
 import org.eclipse.emf.ecore.impl.MinimalEObjectImpl;
 
 import org.eclipse.emf.ecore.util.EObjectContainmentEList;
+import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.ecore.util.InternalEList;
 
 /**
@@ -46,7 +47,7 @@ import org.eclipse.emf.ecore.util.InternalEList;
  *
  * @generated
  */
-public abstract class UnsafeContextImpl extends MinimalEObjectImpl.Container implements UnsafeContext {
+public class UnsafeContextImpl extends MinimalEObjectImpl.Container implements UnsafeContext {
 	/**
 	 * The cached value of the '{@link #getVariables() <em>Variables</em>}' containment reference list.
 	 * <!-- begin-user-doc -->
@@ -56,16 +57,6 @@ public abstract class UnsafeContextImpl extends MinimalEObjectImpl.Container imp
 	 * @ordered
 	 */
 	protected EList<Variable> variables;
-
-	/**
-	 * The cached value of the '{@link #getExecution() <em>Execution</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @see #getExecution()
-	 * @generated
-	 * @ordered
-	 */
-	protected Execution execution;
 
 	/**
 	 * The default value of the '{@link #getEvents() <em>Events</em>}' attribute.
@@ -145,25 +136,9 @@ public abstract class UnsafeContextImpl extends MinimalEObjectImpl.Container imp
 	 * @generated
 	 */
 	public Execution getExecution() {
-		if (execution != null && execution.eIsProxy()) {
-			InternalEObject oldExecution = (InternalEObject) execution;
-			execution = (Execution) eResolveProxy(oldExecution);
-			if (execution != oldExecution) {
-				if (eNotificationRequired())
-					eNotify(new ENotificationImpl(this, Notification.RESOLVE, EkumiPackage.UNSAFE_CONTEXT__EXECUTION,
-							oldExecution, execution));
-			}
-		}
-		return execution;
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public Execution basicGetExecution() {
-		return execution;
+		if (eContainerFeatureID() != EkumiPackage.UNSAFE_CONTEXT__EXECUTION)
+			return null;
+		return (Execution) eInternalContainer();
 	}
 
 	/**
@@ -172,16 +147,7 @@ public abstract class UnsafeContextImpl extends MinimalEObjectImpl.Container imp
 	 * @generated
 	 */
 	public NotificationChain basicSetExecution(Execution newExecution, NotificationChain msgs) {
-		Execution oldExecution = execution;
-		execution = newExecution;
-		if (eNotificationRequired()) {
-			ENotificationImpl notification = new ENotificationImpl(this, Notification.SET,
-					EkumiPackage.UNSAFE_CONTEXT__EXECUTION, oldExecution, newExecution);
-			if (msgs == null)
-				msgs = notification;
-			else
-				msgs.add(notification);
-		}
+		msgs = eBasicSetContainer((InternalEObject) newExecution, EkumiPackage.UNSAFE_CONTEXT__EXECUTION, msgs);
 		return msgs;
 	}
 
@@ -191,11 +157,13 @@ public abstract class UnsafeContextImpl extends MinimalEObjectImpl.Container imp
 	 * @generated
 	 */
 	public void setExecution(Execution newExecution) {
-		if (newExecution != execution) {
+		if (newExecution != eInternalContainer()
+				|| (eContainerFeatureID() != EkumiPackage.UNSAFE_CONTEXT__EXECUTION && newExecution != null)) {
+			if (EcoreUtil.isAncestor(this, newExecution))
+				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
-			if (execution != null)
-				msgs = ((InternalEObject) execution).eInverseRemove(this, EkumiPackage.EXECUTION__CONTEXT,
-						Execution.class, msgs);
+			if (eInternalContainer() != null)
+				msgs = eBasicRemoveFromContainer(msgs);
 			if (newExecution != null)
 				msgs = ((InternalEObject) newExecution).eInverseAdd(this, EkumiPackage.EXECUTION__CONTEXT,
 						Execution.class, msgs);
@@ -271,9 +239,8 @@ public abstract class UnsafeContextImpl extends MinimalEObjectImpl.Container imp
 	public NotificationChain eInverseAdd(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
 		switch (featureID) {
 		case EkumiPackage.UNSAFE_CONTEXT__EXECUTION:
-			if (execution != null)
-				msgs = ((InternalEObject) execution).eInverseRemove(this, EkumiPackage.EXECUTION__CONTEXT,
-						Execution.class, msgs);
+			if (eInternalContainer() != null)
+				msgs = eBasicRemoveFromContainer(msgs);
 			return basicSetExecution((Execution) otherEnd, msgs);
 		}
 		return super.eInverseAdd(otherEnd, featureID, msgs);
@@ -301,14 +268,26 @@ public abstract class UnsafeContextImpl extends MinimalEObjectImpl.Container imp
 	 * @generated
 	 */
 	@Override
+	public NotificationChain eBasicRemoveFromContainerFeature(NotificationChain msgs) {
+		switch (eContainerFeatureID()) {
+		case EkumiPackage.UNSAFE_CONTEXT__EXECUTION:
+			return eInternalContainer().eInverseRemove(this, EkumiPackage.EXECUTION__CONTEXT, Execution.class, msgs);
+		}
+		return super.eBasicRemoveFromContainerFeature(msgs);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
 	public Object eGet(int featureID, boolean resolve, boolean coreType) {
 		switch (featureID) {
 		case EkumiPackage.UNSAFE_CONTEXT__VARIABLES:
 			return getVariables();
 		case EkumiPackage.UNSAFE_CONTEXT__EXECUTION:
-			if (resolve)
-				return getExecution();
-			return basicGetExecution();
+			return getExecution();
 		case EkumiPackage.UNSAFE_CONTEXT__EVENTS:
 			return getEvents();
 		case EkumiPackage.UNSAFE_CONTEXT__EXECUTION_STATUS:
@@ -378,7 +357,7 @@ public abstract class UnsafeContextImpl extends MinimalEObjectImpl.Container imp
 		case EkumiPackage.UNSAFE_CONTEXT__VARIABLES:
 			return variables != null && !variables.isEmpty();
 		case EkumiPackage.UNSAFE_CONTEXT__EXECUTION:
-			return execution != null;
+			return getExecution() != null;
 		case EkumiPackage.UNSAFE_CONTEXT__EVENTS:
 			return EVENTS_EDEFAULT == null ? events != null : !EVENTS_EDEFAULT.equals(events);
 		case EkumiPackage.UNSAFE_CONTEXT__EXECUTION_STATUS:

--- a/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/activities/impl/BasicSequence.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/activities/impl/BasicSequence.java
@@ -26,11 +26,6 @@ public class BasicSequence extends SequenceImpl {
 	}
 	
 	@Override
-	public boolean isSetActivities() {
-		return true;
-	}
-	
-	@Override
 	public void run(Context context) {
 		boolean oneActivityHasFailed = false;
 		

--- a/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/execution/BasicExecution.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/execution/BasicExecution.java
@@ -48,7 +48,7 @@ public class BasicExecution extends ExecutionImpl {
 		Adapter adapter = new StatusToEventAdapter(getContext().getEvents());
 		getActivity().eAdapters().add(adapter);
 		
-		startDate = new Date();
+		setStartDate(new Date());
 		
 		status = RUNNING;
 		runActivityInBackground();                          

--- a/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/execution/BasicExecution.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/execution/BasicExecution.java
@@ -57,9 +57,11 @@ public class BasicExecution extends ExecutionImpl {
 	private void runActivityInBackground() {
 		job = Job.create("Executing " + getActivity().getName(), (ICoreRunnable) monitor -> {
 			context.setExecutionStatus(new BasicExecutionStatus(this, monitor));
+			context.getEvents().hasStarted(this);
 			
 			getActivity().run(context.safe());
 			
+			context.getEvents().hasSucceeded(this);
 			status = SUCCEEDED;
 		});
 		job.schedule();

--- a/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/execution/ExecutionHistory.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/execution/ExecutionHistory.java
@@ -1,0 +1,15 @@
+package fr.kazejiyu.ekumi.core.execution;
+
+import fr.kazejiyu.ekumi.core.ekumi.Execution;
+
+/**
+ * A list of {@link Execution} instances ordered by their 
+ * {@link Execution#getStartDate() start date}.
+ * 
+ * @author Emmanuel CHEBBI
+ */
+public interface ExecutionHistory extends Iterable<Execution> {
+	
+	
+
+}

--- a/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/execution/events/CallbackRegistry.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/execution/events/CallbackRegistry.java
@@ -1,9 +1,12 @@
 package fr.kazejiyu.ekumi.core.execution.events;
 
 import fr.kazejiyu.ekumi.core.execution.listeners.ActivityListener;
+import fr.kazejiyu.ekumi.core.execution.listeners.ExecutionListener;
 import fr.kazejiyu.ekumi.core.execution.listeners.OnActivityFailed;
 import fr.kazejiyu.ekumi.core.execution.listeners.OnActivityStarted;
 import fr.kazejiyu.ekumi.core.execution.listeners.OnActivitySucceeded;
+import fr.kazejiyu.ekumi.core.execution.listeners.OnExecutionStarted;
+import fr.kazejiyu.ekumi.core.execution.listeners.OnExecutionSucceeded;
 
 /**
  * Defines a registry able to manage callbacks for specific events.<br>
@@ -38,5 +41,37 @@ public interface CallbackRegistry {
 	 * 			The listener to call. Must not be {@code null}.
 	 */
 	void onActivitySucceeded(OnActivitySucceeded listener);
+	
+	/**
+	 * Adds a new listener to call when an activity-related event is sent.
+	 * 
+	 * @param listener
+	 * 			The listener to call. Must not be {@code null}.
+	 */
+	void onActivityEvent(ActivityListener listener);
+	
+	/**
+	 * Adds a new listener to call when an execution starts.
+	 * 
+	 * @param listener
+	 *			The listener to call. Must not be {@code null}. 
+	 */
+	void onExecutionStarted(OnExecutionStarted listener);
+	
+	/**
+	 * Adds a new listener to call when an execution succeeds.
+	 * 
+	 * @param listener
+	 * 			The listener to call. Must not be {@code null}.
+	 */
+	void onExecutionSucceeded(OnExecutionSucceeded listener);
+	
+	/**
+	 * Adds a new listener to call when an execution-related event is sent.
+	 * 
+	 * @param listener
+	 * 			The listener to call. Must not be {@code null}.
+	 */
+	void onExecutionEvent(ExecutionListener listener);
 
 }

--- a/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/execution/events/EventSource.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/execution/events/EventSource.java
@@ -1,6 +1,7 @@
 package fr.kazejiyu.ekumi.core.execution.events;
 
 import fr.kazejiyu.ekumi.core.ekumi.Activity;
+import fr.kazejiyu.ekumi.core.ekumi.Execution;
 import fr.kazejiyu.ekumi.core.execution.listeners.ActivityListener;
 
 /**
@@ -36,5 +37,23 @@ public interface EventSource {
 	 * 			Must not be {@code null}.
 	 */
 	void hasFailed(Activity activity);
+	
+	/**
+	 * Triggers an event indicating that execution has started.
+	 * 
+	 * @param execution
+	 * 			The execution that has started.
+	 * 			Must not be {@code null}.
+	 */
+	void hasStarted(Execution execution);
+	
+	/**
+	 * Triggers an event indicating that execution has succeeded.
+	 * 
+	 * @param execution
+	 * 			The execution that ended successfully.
+	 * 			Must not be {@code null}.
+	 */
+	void hasSucceeded(Execution execution);
 
 }

--- a/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/execution/events/impl/BasicEvents.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/execution/events/impl/BasicEvents.java
@@ -1,15 +1,23 @@
 package fr.kazejiyu.ekumi.core.execution.events.impl;
 
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.stream.Stream;
 
 import fr.kazejiyu.ekumi.core.ekumi.Activity;
+import fr.kazejiyu.ekumi.core.ekumi.Execution;
 import fr.kazejiyu.ekumi.core.execution.events.Events;
+import fr.kazejiyu.ekumi.core.execution.listeners.ActivityListener;
+import fr.kazejiyu.ekumi.core.execution.listeners.ExecutionListener;
 import fr.kazejiyu.ekumi.core.execution.listeners.OnActivityFailed;
 import fr.kazejiyu.ekumi.core.execution.listeners.OnActivityStarted;
 import fr.kazejiyu.ekumi.core.execution.listeners.OnActivitySucceeded;
+import fr.kazejiyu.ekumi.core.execution.listeners.OnExecutionStarted;
+import fr.kazejiyu.ekumi.core.execution.listeners.OnExecutionSucceeded;
 
 /**
  * A simple event bus.
@@ -24,27 +32,40 @@ public class BasicEvents implements Events {
 	
 	/** Objects listening for an activity to succeed */
 	private final List<OnActivitySucceeded> activitySucceededListeners = new ArrayList<>();
-
+	
+	/** Objects listening for an activity to change */
+	private final List<ActivityListener> activityListeners = new ArrayList<>();
+	
+	/** Objects listening for an execution to start */
+	private final List<OnExecutionStarted> executionStartedListeners = new ArrayList<>();
+	
+	/** Objects listening for an execution to succeed */
+	private final List<OnExecutionSucceeded> executionSucceededListeners = new ArrayList<>();
+	
+	/** Objects listening for an execution to change */
+	private final List<ExecutionListener> executionListeners = new ArrayList<>();
+	
+	private <T, U extends T> List<T> concat(Collection<T> list1, Collection<U> list2) {
+		return Stream.concat(list1.stream(), list2.stream())
+					 .collect(toList());
+	}
+	
 	@Override
 	public void hasStarted(Activity started) {
-		for (OnActivityStarted listener : activityStartedListeners) {
+		for (OnActivityStarted listener : concat(activityStartedListeners, activityListeners))
 			listener.onActivityStarted(started);
-		}
 	}
 
 	@Override
 	public void hasSucceeded(Activity succeeded) {
-		for (OnActivitySucceeded listener : activitySucceededListeners) {
+		for (OnActivitySucceeded listener : concat(activitySucceededListeners, activityListeners))
 			listener.onActivitySucceeded(succeeded);
-		}
 	}
 
 	@Override
 	public void hasFailed(Activity failed) {
-		for (OnActivityFailed listener : activityFailedListeners) {
+		for (OnActivityFailed listener : concat(activityFailedListeners, activityListeners))
 			listener.onActivityFailed(failed);
-		}
-		
 	}
 
 	@Override
@@ -60,6 +81,38 @@ public class BasicEvents implements Events {
 	@Override
 	public void onActivitySucceeded(OnActivitySucceeded listener) {
 		activitySucceededListeners.add(requireNonNull(listener, "Cannot register a null listener"));
+	}
+
+	@Override
+	public void onActivityEvent(ActivityListener listener) {
+		activityListeners.add(requireNonNull(listener, "Cannot register a null listener"));
+	}
+	
+	@Override
+	public void hasStarted(Execution execution) {
+		for (OnExecutionStarted listener : concat(executionStartedListeners, executionListeners))
+			listener.onExecutionStarted(execution);
+	}
+	
+	@Override
+	public void hasSucceeded(Execution execution) {
+		for (OnExecutionSucceeded listener : concat(executionSucceededListeners, executionListeners))
+			listener.onExecutionSucceeded(execution);
+	}
+
+	@Override
+	public void onExecutionStarted(OnExecutionStarted listener) {
+		executionStartedListeners.add(requireNonNull(listener, "Cannot register a null listener"));
+	}
+
+	@Override
+	public void onExecutionSucceeded(OnExecutionSucceeded listener) {
+		executionSucceededListeners.add(requireNonNull(listener, "Cannot register a null listener"));
+	}
+
+	@Override
+	public void onExecutionEvent(ExecutionListener listener) {
+		executionListeners.add(requireNonNull(listener, "Cannot register a null listener"));
 	}
 
 }

--- a/bundles/fr.kazejiyu.ekumi.ide/.classpath
+++ b/bundles/fr.kazejiyu.ekumi.ide/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/bundles/fr.kazejiyu.ekumi.ide/.project
+++ b/bundles/fr.kazejiyu.ekumi.ide/.project
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>fr.kazejiyu.ekumi.ide</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/fr.kazejiyu.ekumi.ide/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/fr.kazejiyu.ekumi.ide/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,7 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/bundles/fr.kazejiyu.ekumi.ide/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.ekumi.ide/META-INF/MANIFEST.MF
@@ -1,0 +1,12 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: EKumi Eclipse IDE Integration
+Bundle-SymbolicName: fr.kazejiyu.ekumi.ide
+Bundle-Version: 1.0.0.qualifier
+Automatic-Module-Name: fr.kazejiyu.ekumi.ide
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Require-Bundle: fr.kazejiyu.ekumi.core,
+ org.eclipse.e4.core.contexts;bundle-version="1.6.0",
+ org.eclipse.e4.core.di;bundle-version="1.6.100",
+ org.eclipse.core.runtime,
+ org.eclipse.emf.ecore.xmi

--- a/bundles/fr.kazejiyu.ekumi.ide/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.ekumi.ide/META-INF/MANIFEST.MF
@@ -5,6 +5,7 @@ Bundle-SymbolicName: fr.kazejiyu.ekumi.ide
 Bundle-Version: 1.0.0.qualifier
 Automatic-Module-Name: fr.kazejiyu.ekumi.ide
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Export-Package: fr.kazejiyu.ekumi.ide.history
 Require-Bundle: fr.kazejiyu.ekumi.core,
  org.eclipse.e4.core.contexts;bundle-version="1.6.0",
  org.eclipse.e4.core.di;bundle-version="1.6.100",

--- a/bundles/fr.kazejiyu.ekumi.ide/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.ekumi.ide/META-INF/MANIFEST.MF
@@ -11,3 +11,5 @@ Require-Bundle: fr.kazejiyu.ekumi.core,
  org.eclipse.e4.core.di;bundle-version="1.6.100",
  org.eclipse.core.runtime,
  org.eclipse.emf.ecore.xmi
+Service-Component: OSGI-INF/views.xml
+Bundle-ActivationPolicy: lazy

--- a/bundles/fr.kazejiyu.ekumi.ide/OSGI-INF/views.xml
+++ b/bundles/fr.kazejiyu.ekumi.ide/OSGI-INF/views.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0"
+               name="fr.kazejiyu.ekumi.osgi.views">
+   <implementation class="fr.kazejiyu.ekumi.ide.history.internal.WorkspaceExecutionHistoryCreationFunction"/>
+   <service>
+      <provide interface="org.eclipse.e4.core.contexts.IContextFunction"/>
+   </service>
+   <property name="service.context.key" type="String"
+      value="fr.kazejiyu.ekumi.core.execution.ExecutionHistory"/>
+</scr:component>

--- a/bundles/fr.kazejiyu.ekumi.ide/build.properties
+++ b/bundles/fr.kazejiyu.ekumi.ide/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/history/PersistExecutionInWorkspace.java
+++ b/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/history/PersistExecutionInWorkspace.java
@@ -1,0 +1,76 @@
+package fr.kazejiyu.ekumi.ide.history;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
+import fr.kazejiyu.ekumi.core.ekumi.Activity;
+import fr.kazejiyu.ekumi.core.ekumi.Execution;
+import fr.kazejiyu.ekumi.core.execution.listeners.ActivityListener;
+import fr.kazejiyu.ekumi.core.execution.listeners.ExecutionListener;
+
+/**
+ * Watches an {@link Execution} in order to persist it in the workspace each time it changes.<br>
+ * <br>
+ * The execution is persisted under the directory given by {@link WorkspaceExecutionHistory#getLocation()}.
+ * More specifically, it is persisted as an <i>&lt;execution-id&gt;</i>/<i>&lt;activity-name&gt;</i>.ekumi.
+ * 
+ * @author Emmanuel CHEBBI
+ */
+public class PersistExecutionInWorkspace implements ActivityListener, ExecutionListener {
+	
+	/** Set on execution started */
+	private Execution execution;
+
+	@Override
+	public void onExecutionStarted(Execution execution) {
+		this.execution = execution;
+		persistInWorkspaceMetada(execution);
+	}
+
+	@Override
+	public void onActivityFailed(Activity failed) {
+		persistInWorkspaceMetada(execution);
+	}
+
+	@Override
+	public void onActivitySucceeded(Activity succeeded) {
+		persistInWorkspaceMetada(execution);
+	}
+	
+	/**
+	 * Persists given execution as an XMI file in workspace .metadata folder.
+	 * 
+	 * @param execution
+	 * 			The execution to persist.
+	 */
+	private static void persistInWorkspaceMetada(Execution execution) {
+		Resource.Factory.Registry reg = Resource.Factory.Registry.INSTANCE;
+		Map<String, Object> m = reg.getExtensionToFactoryMap();
+		
+		if (! m.containsKey("ekumi"))
+			m.put("ekumi", new XMIResourceFactoryImpl());
+		
+		ResourceSet resourceSet = new ResourceSetImpl();
+		Resource resource = resourceSet.createResource(
+				WorkspaceExecutionHistory.getLocationURI()
+										 .appendSegment(execution.getActivity().getId())
+										 .appendSegment(execution.getActivity().getName())
+										 .appendFileExtension("ekumi")
+		 );
+		
+		resource.getContents().add(execution);
+		
+		try {
+			resource.save(Collections.emptyMap());
+			
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+
+}

--- a/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/history/WorkspaceExecutionHistory.java
+++ b/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/history/WorkspaceExecutionHistory.java
@@ -1,0 +1,63 @@
+package fr.kazejiyu.ekumi.ide.history;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Map;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
+
+import fr.kazejiyu.ekumi.core.EKumiPlugin;
+import fr.kazejiyu.ekumi.core.ekumi.EkumiPackage;
+import fr.kazejiyu.ekumi.core.ekumi.Execution;
+import fr.kazejiyu.ekumi.core.execution.ExecutionHistory;
+
+/**
+ * The history of the {@link Execution}s performed in the Eclipse IDE
+ * and persisted in the workspace. 
+ */
+public class WorkspaceExecutionHistory implements ExecutionHistory {
+	
+	@Override
+	public Iterator<Execution> iterator() {
+		// TODO [Refactor] This is a dumb implementation to test, will be refactored
+		return Arrays.stream(getLocation().toFile().listFiles(File::isDirectory))
+					 .flatMap(file -> Arrays.stream(file.listFiles(f -> f.getName().endsWith(".ekumi"))))
+					 .map(file -> loadExecutionFromFile(file))
+					 .iterator();
+	}
+	
+	public static Path getLocation() {
+		return EKumiPlugin.getStateLocation().resolve("executions");
+	}
+	
+	public static URI getLocationURI() {
+		return EKumiPlugin.getStateLocationURI().appendSegment("executions");
+	}
+	
+	private static Execution loadExecutionFromFile(File file) {
+		try {
+			Resource.Factory.Registry reg = Resource.Factory.Registry.INSTANCE;
+			Map<String, Object> m = reg.getExtensionToFactoryMap();
+				
+			m.putIfAbsent("ekumi", new XMIResourceFactoryImpl());
+				
+			ResourceSet resourceSet = new ResourceSetImpl();
+			
+			resourceSet.getPackageRegistry().put(EkumiPackage.eNS_URI, EkumiPackage.eINSTANCE);
+			Resource resource = resourceSet.getResource(URI.createFileURI(file.getAbsolutePath()), true);
+				
+			return (Execution) resource.getContents().get(0);
+			
+		} catch (Exception e) {
+			e.printStackTrace();
+			return null;
+		}
+	}
+
+}

--- a/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/history/internal/WorkspaceExecutionHistoryCreationFunction.java
+++ b/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/history/internal/WorkspaceExecutionHistoryCreationFunction.java
@@ -1,0 +1,21 @@
+package fr.kazejiyu.ekumi.ide.history.internal;
+
+import org.eclipse.e4.core.contexts.ContextFunction;
+import org.eclipse.e4.core.contexts.ContextInjectionFactory;
+import org.eclipse.e4.core.contexts.IEclipseContext;
+
+import fr.kazejiyu.ekumi.ide.history.WorkspaceExecutionHistory;
+
+public class WorkspaceExecutionHistoryCreationFunction extends ContextFunction {
+	
+	public WorkspaceExecutionHistoryCreationFunction() {
+		System.out.println("WorkspaceExecutionHistoryCreationFunction.WorkspaceExecutionHistory()");
+	}
+	
+	@Override
+	public Object compute(IEclipseContext context) {
+		System.out.println("WorkspaceExecutionHistoryCreationFunction.compute()");
+		return ContextInjectionFactory.make(WorkspaceExecutionHistory.class, context);
+	}
+
+}

--- a/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/history/package-info.java
+++ b/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/history/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Classes aimed to deal with the history of the executions performed in Eclipse IDE.
+ * 
+ * @author Emmmanuel CHEBBI 
+ */
+package fr.kazejiyu.ekumi.ide.history;

--- a/tests/fr.kazejiyu.ekumi.core.test/src/fr/kazejiyu/ekumi/activities/impl/SequenceTest.java
+++ b/tests/fr.kazejiyu.ekumi.core.test/src/fr/kazejiyu/ekumi/activities/impl/SequenceTest.java
@@ -53,13 +53,6 @@ public class SequenceTest {
 			assertThat(empty.getActivities()).isEmpty();
 		}
 		
-		// isSetActivities()
-		
-		@Test @DisplayName("has its activites set")
-		void has_its_activities_set() {
-			assertThat(empty.isSetActivities()).isTrue();
-		}
-		
 		// run()
 		
 		@Test @DisplayName("has 'finished' status after run")
@@ -91,13 +84,6 @@ public class SequenceTest {
 			seq.setRoot(activities.get(0));
 			seq.getRoot().setSuccessor(activities.get(1));
 			seq.getRoot().getSuccessor().setSuccessor(activities.get(2));
-		}
-		
-		// isSetActivities()
-		
-		@Test @DisplayName("has its activites set")
-		void has_its_activities_set() {
-			assertThat(seq.isSetActivities()).isTrue();
 		}
 		
 		// getActivities()

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -55,6 +55,9 @@
 
                                 <!-- Ignore Exceptions -->
                                 <exclude>**/*Exception.class</exclude>
+
+                                <!-- Ignore untestable Activator -->
+                                <exclude>**/EKumiPlugin.class</exclude>
                             </excludes>
                         </configuration>
                         <executions>


### PR DESCRIPTION
Create a new listener, `PersistExecutionInWorkspace` that saves the Execution is watches in workspace metadata. More specifically, under the `.metadata/.plugins/fr.kazejiyu.ekumi.core/` directory.

The execution is saved as an XMI file and can then be loaded by an instance of `WorkspaceExecutionHistory`. Thanks to a new OSGI service, an instance of this class can be injected in the UI thanks to the following code:

```java
class MyPart {

  @Inject
  private ExecutionHistory history;

}
```