### PR TITLE
Create a Run configuration for Activity models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+
+## [Unreleased]
+### Added
+- Launch configurations for Activity ([#20](https://github.com/KazeJiyu/ekumi/pull/20))
 
 ## [0.1.0] - 2018-12-18
 ### Added

--- a/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/execution/BasicExecution.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/execution/BasicExecution.java
@@ -8,6 +8,7 @@ import static fr.kazejiyu.ekumi.core.ekumi.Status.SUCCEEDED;
 import java.util.Date;
 
 import org.eclipse.core.runtime.ICoreRunnable;
+import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.emf.common.notify.Adapter;
 
@@ -55,14 +56,20 @@ public class BasicExecution extends ExecutionImpl {
 			context.setExecutionStatus(new BasicExecutionStatus(this, monitor));
 			context.getEvents().hasStarted(this);
 			
+			// TODO Properly handle monitor of sub tasks
+			monitor.beginTask("Starting the execution", IProgressMonitor.UNKNOWN);
+			
 			try {
 				getActivity().run(context.safe());
-				
+				Thread.sleep(5000);
 				setStatus(SUCCEEDED);
 				context.getEvents().hasSucceeded(this);
-				
-			} catch (Exception e) {
+			} 
+			catch (Exception e) {
 				setStatus(FAILED);
+			} 
+			finally {
+				monitor.done();
 			}
 			
 		});

--- a/bundles/fr.kazejiyu.ekumi.debug.ui/.classpath
+++ b/bundles/fr.kazejiyu.ekumi.debug.ui/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/bundles/fr.kazejiyu.ekumi.debug.ui/.project
+++ b/bundles/fr.kazejiyu.ekumi.debug.ui/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>fr.kazejiyu.ekumi.debug.ui</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/fr.kazejiyu.ekumi.debug.ui/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/fr.kazejiyu.ekumi.debug.ui/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,7 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/bundles/fr.kazejiyu.ekumi.debug.ui/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.ekumi.debug.ui/META-INF/MANIFEST.MF
@@ -1,0 +1,13 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: EKumi Launch Configuration UI
+Bundle-SymbolicName: fr.kazejiyu.ekumi.debug.ui;singleton:=true
+Bundle-Version: 0.1.0
+Automatic-Module-Name: fr.kazejiyu.ekumi.launchConfiguration.ui
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Require-Bundle: fr.kazejiyu.ekumi.core;bundle-version="0.1.0",
+ fr.kazejiyu.ekumi.debug;bundle-version="0.1.0",
+ org.eclipse.debug.ui,
+ org.eclipse.jface,
+ org.eclipse.ui.ide,
+ org.eclipse.core.runtime

--- a/bundles/fr.kazejiyu.ekumi.debug.ui/build.properties
+++ b/bundles/fr.kazejiyu.ekumi.debug.ui/build.properties
@@ -1,0 +1,5 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .,\
+               plugin.xml

--- a/bundles/fr.kazejiyu.ekumi.debug.ui/plugin.xml
+++ b/bundles/fr.kazejiyu.ekumi.debug.ui/plugin.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+   <extension
+         point="org.eclipse.debug.ui.launchShortcuts">
+      <shortcut
+            class="fr.kazejiyu.ekumi.launchconfiguration.ui.LaunchWorkflowShortcut"
+            description="Run an EKumi Workflow"
+            id="fr.kazejiyu.ekumi.launchConfiguration.ui.launchConfigurationType.shortcut"
+            label="Workflow"
+            modes="run">
+         <contextualLaunch>
+            <enablement>
+               <or>
+                  <adapt
+                        type="java.util.List">
+                     <iterate
+                           ifEmpty="false"
+                           operator="and">
+                        <adapt
+                              type="org.eclipse.core.resources.IFile">
+                           <test
+                                 property="org.eclipse.core.resources.extension"
+                                 value="ekumi">
+                           </test>
+                        </adapt>
+                     </iterate>
+                  </adapt>
+               </or>
+            </enablement>
+         </contextualLaunch>
+      </shortcut>
+   </extension>
+   <extension
+         point="org.eclipse.debug.ui.launchConfigurationTabGroups">
+      <launchConfigurationTabGroup
+            class="fr.kazejiyu.ekumi.launchconfiguration.ui.form.EkumiTabGroup"
+            description="Executes a workflow."
+            id="fr.kazejiyu.ekumi.launchConfiguration.ui.launchConfigurationType.tabGroup"
+            type="fr.kazejiyu.ekumi.launchConfiguration.launchConfigurationType">
+      </launchConfigurationTabGroup>
+   </extension>
+
+</plugin>

--- a/bundles/fr.kazejiyu.ekumi.debug.ui/src/fr/kazejiyu/ekumi/launchconfiguration/ui/LaunchWorkflowShortcut.java
+++ b/bundles/fr.kazejiyu.ekumi.debug.ui/src/fr/kazejiyu/ekumi/launchconfiguration/ui/LaunchWorkflowShortcut.java
@@ -1,0 +1,152 @@
+package fr.kazejiyu.ekumi.launchconfiguration.ui;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.PlatformObject;
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationType;
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+import org.eclipse.debug.core.ILaunchManager;
+import org.eclipse.debug.ui.ILaunchShortcut;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.TreeSelection;
+import org.eclipse.ui.IEditorPart;
+
+import fr.kazejiyu.ekumi.core.ekumi.Activity;
+import fr.kazejiyu.ekumi.debug.EKumiRunConfiguration;
+
+/**
+ * <p>Creates a new Launch Configuration for a given EKumi model.</p>
+ * 
+ * <p>The {@link #launch(ISelection, String)} method is supposed to be called
+ * from Eclipse IDE's contextual menu on an *.ekumi model file. It then creates
+ * a corresponding Launch Configuration and runs it.</p>
+ */
+public class LaunchWorkflowShortcut implements ILaunchShortcut {
+
+	@Override
+	public void launch(ISelection selection, String mode) {
+		URI fileURI = selectedFileURI(selection);
+		
+		if (fileURI == null)
+			return;
+		
+		try {
+			Activity activity = loadActivity(fileURI);
+			
+			if (activity == null)
+				return;
+			
+			ILaunchManager manager = DebugPlugin.getDefault().getLaunchManager();
+			ILaunchConfigurationType type = manager.getLaunchConfigurationType(EKumiRunConfiguration.ID);
+			ILaunchConfiguration[] configurations = manager.getLaunchConfigurations(type);
+			
+			// Create a new launch configuration
+			String launchConfigurationName = activity.getName();
+			int index = 1;
+			
+			while (configurationExists(configurations, launchConfigurationName)) {
+				++index;
+				launchConfigurationName = activity.getName() + " (" + index + ")";
+			}
+			
+			ILaunchConfigurationWorkingCopy workingCopy = type.newInstance(null, launchConfigurationName);
+			workingCopy.setAttribute(EKumiRunConfiguration.EKUMI_MODEL_URI, activity.eResource().getURI().toString());
+			ILaunchConfiguration configuration = workingCopy.doSave();
+			
+			// Run the new launch configuration
+			configuration.launch(ILaunchManager.RUN_MODE, null);
+			
+		} catch(IOException e) {
+			e.printStackTrace();
+		}
+		catch (CoreException e) {
+			e.printStackTrace();
+		}
+	}
+
+	@Override
+	public void launch(IEditorPart editor, String mode) {
+		// should not be called
+	}
+	
+	/**
+	 * Returns whether a launch configuration with the given name already exists.
+	 * 
+	 * @param configurations
+	 * 			The launch configurations to check.
+	 * @param name
+	 * 			The name to validate.
+	 * 
+	 * @return whether a launch configuration with the given name already exists
+	 */
+	private static boolean configurationExists(ILaunchConfiguration[] configurations, String name) {
+		for (ILaunchConfiguration launchConfiguration : configurations) {
+			if (launchConfiguration.getName().equals(name)) {
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	/**
+	 * Returns the URI of the selected file.
+	 * 
+	 * @param selection
+	 * 			The current selection
+	 * 
+	 * @return the URI of the selected file, or null if no URI can be found from the selection 
+	 */
+	private static URI selectedFileURI(ISelection selection) {
+		if (selection.isEmpty())
+			return null;
+		
+		if (! (selection instanceof TreeSelection))
+			return null;
+		
+		IStructuredSelection tselection = (IStructuredSelection) selection;
+		Object selectedElement = tselection.getFirstElement();
+		
+		if (! (selectedElement instanceof PlatformObject))
+			return null;
+		
+		PlatformObject object = (PlatformObject) selectedElement;
+		IPath path = object.getAdapter(IFile.class).getFullPath();
+		IFile file = ResourcesPlugin.getWorkspace().getRoot().getFile(path);
+		
+		return URI.createPlatformResourceURI(file.getFullPath().toString(), true);
+	}
+	
+	/**
+	 * Loads an Activity from the given URI.
+	 * 
+	 * @param uri
+	 * 			The URI corresponding to the Resource to load.
+	 * 
+	 * @return the loaded Activity or {@code null} if the Resource does not contain any
+	 * 
+	 * @throws IOException if an I/O error occurs while loading the Resource
+	 */
+	private static Activity loadActivity(URI uri) throws IOException {
+		ResourceSet resourceSet = new ResourceSetImpl();
+		Resource resource = resourceSet.createResource(uri);
+		resource.load(Collections.emptyMap());
+		
+		if (resource.getContents().isEmpty())
+			return null;
+		
+		return (Activity) resource.getContents().get(0);
+	}
+
+}

--- a/bundles/fr.kazejiyu.ekumi.debug.ui/src/fr/kazejiyu/ekumi/launchconfiguration/ui/form/ChooseActivityModelTab.java
+++ b/bundles/fr.kazejiyu.ekumi.debug.ui/src/fr/kazejiyu/ekumi/launchconfiguration/ui/form/ChooseActivityModelTab.java
@@ -1,0 +1,136 @@
+package fr.kazejiyu.ekumi.launchconfiguration.ui.form;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.PlatformObject;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+import org.eclipse.debug.ui.AbstractLaunchConfigurationTab;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.jface.dialogs.Dialog;
+import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.jface.layout.GridLayoutFactory;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.KeyAdapter;
+import org.eclipse.swt.events.KeyEvent;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Group;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Text;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.dialogs.ElementTreeSelectionDialog;
+import org.eclipse.ui.model.BaseWorkbenchContentProvider;
+import org.eclipse.ui.model.WorkbenchLabelProvider;
+
+import fr.kazejiyu.ekumi.core.ekumi.Activity;
+import fr.kazejiyu.ekumi.debug.EKumiRunConfiguration;
+
+/**
+ * A tab allowing to choose the {@link Activity} to execute. 
+ */
+public class ChooseActivityModelTab extends AbstractLaunchConfigurationTab {
+
+	/** Contains the URI of the Activity to execute */
+	private Text modelURI;
+	
+    @Override
+    public void createControl(Composite parent) {
+        Composite comp = new Group(parent, SWT.BORDER);
+        setControl(comp);
+
+        GridLayoutFactory.swtDefaults().numColumns(3).applyTo(comp);
+
+        Label label = new Label(comp, SWT.NONE);
+        label.setText("Activity's URI:");
+        GridDataFactory.swtDefaults().applyTo(label);
+
+        modelURI = new Text(comp, SWT.BORDER);
+        modelURI.setText("EKumi Workflow file");
+        modelURI.addKeyListener(new DirtyDialogOnInput());
+        
+        Button browse = new Button(comp, SWT.NONE);
+        browse.setText("Browse");
+        browse.addSelectionListener(new SelectWorkspaceResource());
+        
+        GridDataFactory.fillDefaults().grab(true, false).applyTo(modelURI);
+    }
+
+    @Override
+    public void setDefaults(ILaunchConfigurationWorkingCopy configuration) {
+    	// nothing to initialize
+    }
+
+    @Override
+    public void initializeFrom(ILaunchConfiguration configuration) {
+        try {
+            String consoleText = configuration.getAttribute(EKumiRunConfiguration.EKUMI_MODEL_URI, "");
+            modelURI.setText(consoleText);
+            
+        } catch (CoreException e) {
+        	e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void performApply(ILaunchConfigurationWorkingCopy configuration) {
+        configuration.setAttribute(EKumiRunConfiguration.EKUMI_MODEL_URI, modelURI.getText());
+    }
+
+    @Override
+    public String getName() {
+        return "Choose Activity";
+    }
+
+    /**
+     * <p>Opens a dialog allowing the user to select a resource from the workspace</p>
+     * 
+     * TODO Add a validator to ensure that the user selects a valid resource
+     */
+    private final class SelectWorkspaceResource extends SelectionAdapter {
+    	
+		@Override
+		public void widgetSelected(SelectionEvent e) {
+			Shell shell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
+			ElementTreeSelectionDialog dialog = new ElementTreeSelectionDialog(shell, new WorkbenchLabelProvider(), new BaseWorkbenchContentProvider());
+			
+			dialog.setTitle("Workspace");
+			dialog.setMessage("Select an activity (*.ekumi)");
+			dialog.setInput(ResourcesPlugin.getWorkspace().getRoot());
+			
+			if (dialog.open() == Dialog.OK) {
+				Object selected = dialog.getResult()[0];
+				
+				PlatformObject object = (PlatformObject) selected;
+				IPath path = object.getAdapter(IFile.class).getFullPath();
+				IFile file = ResourcesPlugin.getWorkspace().getRoot().getFile(path);
+				
+				URI uri = URI.createPlatformResourceURI(file.getFullPath().toString(), true);
+				ChooseActivityModelTab.this.modelURI.setText(uri.toString());
+				
+				setDirty(true);
+				updateLaunchConfigurationDialog();
+			}
+		}
+		
+	}
+
+	/**
+     * Dirty the launch configuration dialog when the user type something.
+     */
+	private final class DirtyDialogOnInput extends KeyAdapter {
+		
+		@Override
+		public void keyPressed(KeyEvent event) {
+			setDirty(true);
+			updateLaunchConfigurationDialog();
+		}
+		
+	}
+
+}

--- a/bundles/fr.kazejiyu.ekumi.debug.ui/src/fr/kazejiyu/ekumi/launchconfiguration/ui/form/EkumiTabGroup.java
+++ b/bundles/fr.kazejiyu.ekumi.debug.ui/src/fr/kazejiyu/ekumi/launchconfiguration/ui/form/EkumiTabGroup.java
@@ -1,0 +1,17 @@
+package fr.kazejiyu.ekumi.launchconfiguration.ui.form;
+
+import org.eclipse.debug.ui.AbstractLaunchConfigurationTabGroup;
+import org.eclipse.debug.ui.ILaunchConfigurationDialog;
+import org.eclipse.debug.ui.ILaunchConfigurationTab;
+
+/**
+ * Main page for configuring EKumi Launch Configurations. 
+ */
+public class EkumiTabGroup extends AbstractLaunchConfigurationTabGroup {
+	
+	@Override
+	public void createTabs(ILaunchConfigurationDialog dialog, String mode) {
+		setTabs(new ILaunchConfigurationTab[] { new ChooseActivityModelTab() });
+	}
+
+}

--- a/bundles/fr.kazejiyu.ekumi.debug/.classpath
+++ b/bundles/fr.kazejiyu.ekumi.debug/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/bundles/fr.kazejiyu.ekumi.debug/.project
+++ b/bundles/fr.kazejiyu.ekumi.debug/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>fr.kazejiyu.ekumi.debug</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/fr.kazejiyu.ekumi.debug/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/fr.kazejiyu.ekumi.debug/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,7 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/bundles/fr.kazejiyu.ekumi.debug/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.ekumi.debug/META-INF/MANIFEST.MF
@@ -1,0 +1,15 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: EKumi Launch Configuration
+Bundle-SymbolicName: fr.kazejiyu.ekumi.debug;singleton:=true
+Bundle-Version: 0.1.0
+Automatic-Module-Name: fr.kazejiyu.ekumi.launchConfiguration
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Require-Bundle: org.eclipse.debug.core,
+ org.eclipse.core.runtime,
+ org.eclipse.debug.ui,
+ org.eclipse.jface,
+ org.eclipse.ui.ide,
+ org.eclipse.emf.ecore,
+ fr.kazejiyu.ekumi.core
+Export-Package: fr.kazejiyu.ekumi.debug

--- a/bundles/fr.kazejiyu.ekumi.debug/build.properties
+++ b/bundles/fr.kazejiyu.ekumi.debug/build.properties
@@ -1,0 +1,5 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .,\
+               plugin.xml

--- a/bundles/fr.kazejiyu.ekumi.debug/plugin.xml
+++ b/bundles/fr.kazejiyu.ekumi.debug/plugin.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+   <extension
+         point="org.eclipse.debug.core.launchConfigurationTypes">
+      <launchConfigurationType
+            delegate="fr.kazejiyu.ekumi.debug.RunWorkflow"
+            id="fr.kazejiyu.ekumi.launchConfiguration.launchConfigurationType"
+            modes="run"
+            name="Workflow">
+      </launchConfigurationType>
+   </extension>
+
+</plugin>

--- a/bundles/fr.kazejiyu.ekumi.debug/src/fr/kazejiyu/ekumi/debug/EKumiRunConfiguration.java
+++ b/bundles/fr.kazejiyu.ekumi.debug/src/fr/kazejiyu/ekumi/debug/EKumiRunConfiguration.java
@@ -1,0 +1,17 @@
+package fr.kazejiyu.ekumi.debug;
+
+/**
+ * Stores constants about EKumi Run Configurations.
+ */
+public final class EKumiRunConfiguration {
+	
+	/** ID of the EKumi extension contribution to the org.eclipse.debug.ui.launchShortcuts extension point */
+	public static final String ID = "fr.kazejiyu.ekumi.launchConfiguration.launchConfigurationType";
+	
+	/** Name of the configuration's attribute used to specify the URI of the Activity to execute */
+	public static final String EKUMI_MODEL_URI = "fr.kazejiyu.ekumi.launchConfiguration.model";
+	
+	private EKumiRunConfiguration() {
+		// should not be instantiated
+	}
+}

--- a/bundles/fr.kazejiyu.ekumi.debug/src/fr/kazejiyu/ekumi/debug/RunWorkflow.java
+++ b/bundles/fr.kazejiyu.ekumi.debug/src/fr/kazejiyu/ekumi/debug/RunWorkflow.java
@@ -1,0 +1,55 @@
+package fr.kazejiyu.ekumi.debug;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.debug.core.ILaunch;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.model.LaunchConfigurationDelegate;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+
+import fr.kazejiyu.ekumi.core.ekumi.Activity;
+import fr.kazejiyu.ekumi.core.ekumi.EkumiFactory;
+import fr.kazejiyu.ekumi.core.ekumi.Execution;
+
+/**
+ * <p>Executes a given {@link Activity}</p>
+ * 
+ * <p>In order to be executed, an Activity must belong to a {@link Resource}
+ * and the resource's URI must be specified in the {@link ILaunchConfiguration configuration}
+ * with an attribute called {@value EKumiRunConfiguration#EKUMI_MODEL_URI}
+ */
+public final class RunWorkflow extends LaunchConfigurationDelegate {
+
+	@Override
+	public void launch(ILaunchConfiguration configuration, String mode, ILaunch launch, IProgressMonitor monitor) throws CoreException {
+		String uri = configuration.getAttribute(EKumiRunConfiguration.EKUMI_MODEL_URI, "");
+		
+		if (uri.isEmpty())
+			// TODO log error
+			return;
+		
+		ResourceSet resourceSet = new ResourceSetImpl();
+		Resource resource = resourceSet.createResource(URI.createURI(uri));
+		
+		try {
+			resource.load(Collections.emptyMap());
+			
+			Activity activity = (Activity) resource.getContents().get(0);
+			
+			Execution execution = EkumiFactory.eINSTANCE.createExecution();
+			execution.setActivity(activity);
+			execution.start();
+			
+		} catch (IOException e) {
+			// TODO Process exception properly
+			e.printStackTrace();
+		}
+	}
+
+}


### PR DESCRIPTION
Provides a new Launch Configuration in _run_ mode to execute Activity models.

Models can be executed from the Model Explorer with the help of the context menu:

![The context menu allows to execute an Activity](https://user-images.githubusercontent.com/25926433/50492413-bd6be080-0a17-11e9-91c0-7fa8296cd63d.png)

Using the context menu dynamically creates a new run configuration based on the name of the Activity and then launch it.

> _NB:_ for this reason the activity's name currently has to be a non-empty string.

![The Run Configurations dialog displays activity executions](https://user-images.githubusercontent.com/25926433/50492632-12f4bd00-0a19-11e9-94e9-1dadc3caa675.png)

For the moment no test have been implemented because they would have to deal with Resource loading and I didn't want to spent time too much time on this right now.