### PR TITLE
Automatically updates the Execution History view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Added
 - Launch configurations for Activity ([#20](https://github.com/KazeJiyu/ekumi/pull/20))
+- Automatic update of the History View ([#22](https://github.com/KazeJiyu/ekumi/pull/22))
 
 ## [0.1.0] - 2018-12-18
 ### Added

--- a/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/execution/BasicExecution.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/execution/BasicExecution.java
@@ -61,7 +61,6 @@ public class BasicExecution extends ExecutionImpl {
 			
 			try {
 				getActivity().run(context.safe());
-				Thread.sleep(5000);
 				setStatus(SUCCEEDED);
 				context.getEvents().hasSucceeded(this);
 			} 

--- a/bundles/fr.kazejiyu.ekumi.debug/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.ekumi.debug/META-INF/MANIFEST.MF
@@ -11,5 +11,6 @@ Require-Bundle: org.eclipse.debug.core,
  org.eclipse.jface,
  org.eclipse.ui.ide,
  org.eclipse.emf.ecore,
- fr.kazejiyu.ekumi.core
+ fr.kazejiyu.ekumi.core,
+ fr.kazejiyu.ekumi.ide
 Export-Package: fr.kazejiyu.ekumi.debug

--- a/bundles/fr.kazejiyu.ekumi.debug/src/fr/kazejiyu/ekumi/debug/RunWorkflow.java
+++ b/bundles/fr.kazejiyu.ekumi.debug/src/fr/kazejiyu/ekumi/debug/RunWorkflow.java
@@ -2,6 +2,7 @@ package fr.kazejiyu.ekumi.debug;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Date;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -13,9 +14,11 @@ import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 
+import fr.kazejiyu.ekumi.EKumiPlugin;
 import fr.kazejiyu.ekumi.core.ekumi.Activity;
 import fr.kazejiyu.ekumi.core.ekumi.EkumiFactory;
 import fr.kazejiyu.ekumi.core.ekumi.Execution;
+import fr.kazejiyu.ekumi.ide.history.PersistExecution;
 
 /**
  * <p>Executes a given {@link Activity}</p>
@@ -43,6 +46,12 @@ public final class RunWorkflow extends LaunchConfigurationDelegate {
 			Activity activity = (Activity) resource.getContents().get(0);
 			
 			Execution execution = EkumiFactory.eINSTANCE.createExecution();
+			
+			// Ensure execution history is persisted in workspace's metadata
+			execution.getContext().getEvents().onExecutionEvent(new PersistExecution(EKumiPlugin.getStateLocationURI().appendSegment("executions")));
+			
+			execution.setId(new Date().hashCode() + "." + activity.getId());
+			execution.setName(activity.getName());
 			execution.setActivity(activity);
 			execution.start();
 			

--- a/bundles/fr.kazejiyu.ekumi.ide.events/.classpath
+++ b/bundles/fr.kazejiyu.ekumi.ide.events/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/bundles/fr.kazejiyu.ekumi.ide.events/.project
+++ b/bundles/fr.kazejiyu.ekumi.ide.events/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>fr.kazejiyu.ekumi.ide.events</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/fr.kazejiyu.ekumi.ide.events/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/fr.kazejiyu.ekumi.ide.events/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,7 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/bundles/fr.kazejiyu.ekumi.ide.events/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.ekumi.ide.events/META-INF/MANIFEST.MF
@@ -1,0 +1,8 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: EKumi IDE Event Constants
+Bundle-SymbolicName: fr.kazejiyu.ekumi.ide.events
+Bundle-Version: 0.1.0
+Automatic-Module-Name: fr.kazejiyu.ekumi.ide.events
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Export-Package: fr.kazejiyu.ekumi.ide.events

--- a/bundles/fr.kazejiyu.ekumi.ide.events/build.properties
+++ b/bundles/fr.kazejiyu.ekumi.ide.events/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/bundles/fr.kazejiyu.ekumi.ide.events/src/fr/kazejiyu/ekumi/ide/events/EKumiEvents.java
+++ b/bundles/fr.kazejiyu.ekumi.ide.events/src/fr/kazejiyu/ekumi/ide/events/EKumiEvents.java
@@ -1,0 +1,40 @@
+package fr.kazejiyu.ekumi.ide.events;
+
+/**
+ * <p>Defines topics for EKumi events.</p>
+ * 
+ * <p>Users can subscribe to these topics with an {@code IEventBroker}
+ * in order to receive specific events.</p>
+ */
+public final class EKumiEvents {
+	
+	private EKumiEvents() {
+		// should not be instantiated
+	}
+	
+	/**
+	 * Root topic for all EKumi-related events/
+	 */
+	public static final String EKUMI_TOPIC = "fr/kazejiyu/ekumi/ide";
+	
+	/**
+	 * Subscribe to this topic to receive all EKumi-related events.
+	 */
+	public static final String EKUMI_ALL_TOPICS = EKUMI_TOPIC + "/*";
+	
+	/**
+	 * Root topic for all history-related events.
+	 */
+	public static final String HISTORY_TOPIC = EKUMI_TOPIC + "/history";
+	
+	/**
+	 * Subscribe to this topic to receive an event each time a new execution is launched.
+	 */
+	public static final String HISTORY_EXECUTION_STARTED = HISTORY_TOPIC + "/execution_started";
+	
+	/**
+	 * Subscribe to this topic to receive an event each time an execution is updated.
+	 */
+	public static final String HISTORY_EXECUTION_CHANGED = HISTORY_TOPIC + "/execution_changed";
+
+}

--- a/bundles/fr.kazejiyu.ekumi.ide/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.ekumi.ide/META-INF/MANIFEST.MF
@@ -10,7 +10,10 @@ Require-Bundle: fr.kazejiyu.ekumi.core,
  org.eclipse.e4.core.contexts;bundle-version="1.6.0",
  org.eclipse.e4.core.di;bundle-version="1.6.100",
  org.eclipse.core.runtime,
- org.eclipse.emf.ecore.xmi
+ org.eclipse.emf.ecore.xmi,
+ org.apache.commons.io,
+ org.eclipse.e4.core.services,
+ fr.kazejiyu.ekumi.ide.events;bundle-version="0.1.0"
 Service-Component: OSGI-INF/history.xml,
  OSGI-INF/catalogs.xml
 Bundle-ActivationPolicy: lazy

--- a/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/history/PostEventOnExecutionChange.java
+++ b/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/history/PostEventOnExecutionChange.java
@@ -1,0 +1,76 @@
+package fr.kazejiyu.ekumi.ide.history;
+
+import static java.util.Objects.requireNonNull;
+
+import static fr.kazejiyu.ekumi.ide.history.PersistedHistory.loadExecutionFromFile;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import org.apache.commons.io.monitor.FileAlterationListenerAdaptor;
+import org.eclipse.e4.core.services.events.IEventBroker;
+
+import fr.kazejiyu.ekumi.core.ekumi.Execution;
+import fr.kazejiyu.ekumi.ide.events.EKumiEvents;
+
+/**
+ * Sends specific events when an execution (*.ekumi) file changes.
+ */
+class PostEventOnExecutionChange extends FileAlterationListenerAdaptor {
+	
+	/** Used to send events */
+	private final IEventBroker bus;
+	
+	/**
+	 * Creates a new file alteration listener.
+	 * 
+	 * @param bus
+	 * 			The event broker to use to send events.
+	 */
+	public PostEventOnExecutionChange(IEventBroker bus) {
+		this.bus = requireNonNull(bus, "The IEventBroker must not be null");
+	}
+
+    @Override
+    public void onFileCreate(File file) {
+    	process(file, EKumiEvents.HISTORY_EXECUTION_STARTED);
+    }
+ 
+    @Override
+    public void onFileDelete(File file) {
+    	// nothing to do
+    }
+ 
+    @Override
+    public void onFileChange(File file) {
+    	process(file, EKumiEvents.HISTORY_EXECUTION_CHANGED);
+    }
+
+	private void process(File file, String event) {
+		try {
+    		Execution execution = load(file);
+    		System.out.println("POSTING " + event + " TO " + bus);
+    		bus.post(event, execution);
+    		System.out.println("POSTED");
+    		
+    	} catch (Exception e) {
+    		// TODO Proper logging
+    		e.printStackTrace();
+    	}
+	}
+    
+    private Execution load(File file) {
+    	// Ignore lock files
+    	if (file.getName().equals(".lock"))
+    		return null;
+    	
+    	Path lock = file.getParentFile().toPath().resolve(".lock");
+    	
+    	// TODO Add a timer to prevent infinite loops
+    	while (lock.toFile().exists())
+    		;
+    	
+    	return loadExecutionFromFile(file);
+    }
+    
+}

--- a/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/history/internal/WorkspaceHistoryCreationFunction.java
+++ b/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/history/internal/WorkspaceHistoryCreationFunction.java
@@ -1,8 +1,11 @@
 package fr.kazejiyu.ekumi.ide.history.internal;
 
+import javax.inject.Inject;
+
 import org.eclipse.e4.core.contexts.ContextInjectionFactory;
 import org.eclipse.e4.core.contexts.IContextFunction;
 import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.eclipse.e4.core.services.events.IEventBroker;
 
 import fr.kazejiyu.ekumi.EKumiPlugin;
 import fr.kazejiyu.ekumi.core.ekumi.History;
@@ -22,9 +25,19 @@ import fr.kazejiyu.ekumi.ide.history.PersistedHistory;
  */
 public class WorkspaceHistoryCreationFunction implements IContextFunction {
 	
+	@Inject
+	IEventBroker broker;
+	
 	@Override
 	public Object compute(IEclipseContext context, String contextKey) {
 		PersistedHistory history = new PersistedHistory(EKumiPlugin.getStateLocation().resolve("executions"));
+		try {
+			history.notifyOnChange(context.get(IEventBroker.class));
+			
+		} catch (Exception e) {
+			// TODO Properly log error
+			e.printStackTrace();
+		}
 		ContextInjectionFactory.inject(history, context);
 		return history;
 	}

--- a/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/internal/lock/LockFolderFile.java
+++ b/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/internal/lock/LockFolderFile.java
@@ -1,0 +1,51 @@
+package fr.kazejiyu.ekumi.ide.internal.lock;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.emf.common.util.URI;
+
+/**
+ * Temporarily creates a <i>.lock</i> in a given directory
+ * for the scope of a try-with-resource statement.
+ */
+public class LockFolderFile implements AutoCloseable {
+	
+	/**
+	 * The .lock file
+	 */
+	private final Path lock;
+	
+	/**
+	 * Creates a <i>.lock</i> file under given directory.
+	 * 
+	 * @param folderURI
+	 * 			The URI of the folder to lock.
+	 * 
+	 * @throws IOException if an error occurs while creating the lock file
+	 */
+	public LockFolderFile(URI folderURI) throws IOException  {
+		try {
+			lock = Paths.get(FileLocator.resolve(new URL(folderURI.appendSegment(".lock").toString())).toURI());
+			
+			Files.createDirectories(lock.getParent());
+			Files.createFile(lock);
+			
+		} catch (Exception e) {
+			throw new IOException("Unable to create the .lock file under " + folderURI, e);
+		}
+	}
+
+	/**
+	 * Deletes the lock file from the hard disk.
+	 */
+	@Override
+	public void close() throws IOException {
+		Files.deleteIfExists(lock);
+	}
+	
+}

--- a/bundles/fr.kazejiyu.ekumi.ui.e4/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.ekumi.ui.e4/META-INF/MANIFEST.MF
@@ -5,16 +5,20 @@ Bundle-SymbolicName: fr.kazejiyu.ekumi.ui.e4;singleton:=true
 Bundle-Version: 0.1.0
 Bundle-Vendor: Emmanuel CHEBBI
 Require-Bundle: javax.inject,
-  org.eclipse.osgi,
-  org.eclipse.jface,
-  org.eclipse.e4.ui.model.workbench,
-  org.eclipse.e4.ui.di,
-  org.eclipse.e4.ui.services,
-  org.eclipse.e4.core.di.annotations,
-  fr.kazejiyu.ekumi.core,
-  fr.kazejiyu.ekumi.core.edit,
-  org.eclipse.emf.edit.ui,
-  fr.kazejiyu.ekumi.ide
+ org.eclipse.osgi,
+ org.eclipse.jface,
+ org.eclipse.e4.ui.model.workbench,
+ org.eclipse.e4.ui.di,
+ org.eclipse.e4.ui.services,
+ org.eclipse.e4.core.di.annotations,
+ fr.kazejiyu.ekumi.core,
+ fr.kazejiyu.ekumi.core.edit,
+ org.eclipse.emf.edit.ui,
+ fr.kazejiyu.ekumi.ide,
+ org.eclipse.e4.core.services,
+ org.apache.commons.io,
+ org.eclipse.e4.core.di,
+ fr.kazejiyu.ekumi.ide.events;bundle-version="0.1.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: javax.annotation;version="1.0.0";resolution:=optional,
   javax.inject;version="1.0.0"

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -19,6 +19,7 @@
         <module>fr.kazejiyu.ekumi.core.editor</module>
         <module>fr.kazejiyu.ekumi.datatypes</module>
         <module>fr.kazejiyu.ekumi.ide</module>
+        <module>fr.kazejiyu.ekumi.ide.events</module>
         <module>fr.kazejiyu.ekumi.languages.java</module>
 		<module>fr.kazejiyu.ekumi.ui.e4</module>
 	</modules>

--- a/releng/fr.kazejiyu.ekumi.target/fr.kazejiyu.ekumi.target.target
+++ b/releng/fr.kazejiyu.ekumi.target/fr.kazejiyu.ekumi.target.target
@@ -16,6 +16,7 @@
 <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20180606145124/repository"/>
 	<unit id="com.google.inject" version="3.0.0.v201605172100"/>
 	<unit id="com.google.inject.source" version="3.0.0.v201605172100"/>
+	<unit id="org.apache.commons.io" version="2.2.0.v201405211200"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.emf.sdk.feature.group" version="2.13.0.v20170609-0928"/>

--- a/tests/fr.kazejiyu.ekumi.ide.test/META-INF/MANIFEST.MF
+++ b/tests/fr.kazejiyu.ekumi.ide.test/META-INF/MANIFEST.MF
@@ -7,4 +7,5 @@ Bundle-Vendor: Emmanuel CHEBBI
 Fragment-Host: fr.kazejiyu.ekumi.ide;bundle-version="0.1.0"
 Automatic-Module-Name: fr.kazejiyu.ekumi.ide.test
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: fr.kazejiyu.ekumi.tests.common;bundle-version="0.1.0"
+Require-Bundle: fr.kazejiyu.ekumi.tests.common;bundle-version="0.1.0",
+ org.mockito

--- a/tests/fr.kazejiyu.ekumi.ide.test/src/fr/kazejiyu/ekumi/ide/history/ExecutionMatcher.java
+++ b/tests/fr.kazejiyu.ekumi.ide.test/src/fr/kazejiyu/ekumi/ide/history/ExecutionMatcher.java
@@ -1,0 +1,32 @@
+package fr.kazejiyu.ekumi.ide.history;
+
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.mockito.ArgumentMatcher;
+
+import fr.kazejiyu.ekumi.core.ekumi.Execution;
+
+/**
+ * Helps to match a given Execution instance.
+ */
+class ExecutionMatcher implements ArgumentMatcher<Execution> {
+	
+	/** Matches all instances that are equal to this one */
+	private final Execution expected;
+	
+	/**
+	 * Creates a new matcher.
+	 * 
+	 * @param expected
+	 * 			The reference instance.
+	 */
+	public ExecutionMatcher(Execution expected) {
+		this.expected = expected;
+	}
+
+	@Override
+	public boolean matches(Execution execution) {
+		System.out.println("EXECUTION MATCHER");
+		return EcoreUtil.equals(execution, expected);
+	}
+
+}

--- a/tests/fr.kazejiyu.ekumi.ide.test/src/fr/kazejiyu/ekumi/ide/history/PostEventOnExecutionChangeTest.java
+++ b/tests/fr.kazejiyu.ekumi.ide.test/src/fr/kazejiyu/ekumi/ide/history/PostEventOnExecutionChangeTest.java
@@ -1,0 +1,123 @@
+package fr.kazejiyu.ekumi.ide.history;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.verify;
+
+import java.io.File;
+
+import org.assertj.core.api.WithAssertions;
+import org.eclipse.e4.core.services.events.IEventBroker;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+
+import fr.kazejiyu.ekumi.core.ekumi.Execution;
+import fr.kazejiyu.ekumi.ide.events.EKumiEvents;
+import fr.kazejiyu.ekumi.tests.common.mock.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("A PostEventOnExecutionChange")
+public class PostEventOnExecutionChangeTest implements WithAssertions {
+	
+	@Mock IEventBroker broker;
+	
+	Execution expectedExecution;
+	
+	PostEventOnExecutionChange listener;
+	
+	File expectedExecutionModel = new File("./rsc/executions/2018.09.20.1120402040.sequence-13/Sequence n°13.ekumi");
+	
+	@BeforeEach
+	void setup() {
+		listener = new PostEventOnExecutionChange(broker);
+		expectedExecution = PersistedHistory.loadExecutionFromFile(expectedExecutionModel);
+	}
+	
+	@Nested @DisplayName("when instantiated")
+	class WhenInstantiated {
+		
+		@Test @DisplayName("throws if the IEventBroker is null")
+		void throws_if_the_IEventBroker_is_null() {
+			assertThatNullPointerException().isThrownBy(() ->
+				new PostEventOnExecutionChange(null)
+			);
+		}
+		
+	}
+	
+	@Nested @DisplayName("when a file is created")
+	class WhenAFileIsCreated {
+		
+		@Test @DisplayName("does nothing if the file is '.lock'")
+		void does_nothing_if_the_file_is_lock() {
+			File lock = new File(".lock");
+			listener.onFileCreate(lock);
+		}
+		
+		@Test @DisplayName("does not throw when the .ekumi file does not exist")
+		void does_not_throw_when_the_ekumi_file_does_not_exist() {
+			File model = new File("execution.ekumi");
+			listener.onFileCreate(model);
+		}
+		
+		@Test @DisplayName("posts the appropriate event")
+		void posts_the_appropriate_event() {
+			listener.onFileCreate(expectedExecutionModel);
+			verify(broker, only()).post(eq(EKumiEvents.HISTORY_EXECUTION_STARTED), any());
+		}
+		
+		@Test @DisplayName("posts the appropriate execution")
+		void posts_the_appropriate_execution() {
+			listener.onFileCreate(expectedExecutionModel);
+			verify(broker, only()).post(any(), argThat(new ExecutionMatcher(expectedExecution)));
+		}
+		
+	}
+	
+	@Nested @DisplayName("when a file is deleted")
+	class WhenAFileIsDeleted {
+		
+		@Test @DisplayName("does nothing")
+		void does_nothing_if_the_file_is_lock() {
+			File deleted = new File(".");
+			listener.onFileDelete(deleted);
+		}
+		
+	}
+	
+	@Nested @DisplayName("when a file changes")
+	class WhenAFileChanges {
+		
+		@Test @DisplayName("does nothing if the file is '.lock'")
+		void does_nothing_if_the_file_is_lock() {
+			File lock = new File(".lock");
+			listener.onFileChange(lock);
+		}
+		
+		@Test @DisplayName("does not throw when the .ekumi file does not exist")
+		void does_not_throw_when_the_ekumi_file_does_not_exist() {
+			File model = new File("execution.ekumi");
+			listener.onFileChange(model);
+		}
+		
+		@Test @DisplayName("posts the appropriate event")
+		void posts_the_appropriate_event() {
+			listener.onFileChange(expectedExecutionModel);
+			verify(broker, only()).post(eq(EKumiEvents.HISTORY_EXECUTION_CHANGED), any());
+		}
+		
+		@Test @DisplayName("posts the appropriate execution")
+		void posts_the_appropriate_execution() {
+			listener.onFileChange(expectedExecutionModel);
+			verify(broker, only()).post(any(), argThat(new ExecutionMatcher(expectedExecution)));
+		}
+		
+	}
+
+}

--- a/tests/fr.kazejiyu.ekumi.ide.test/src/fr/kazejiyu/ekumi/ide/history/internal/WorkspaceHistoryCreationFunctionTest.java
+++ b/tests/fr.kazejiyu.ekumi.ide.test/src/fr/kazejiyu/ekumi/ide/history/internal/WorkspaceHistoryCreationFunctionTest.java
@@ -3,14 +3,19 @@ package fr.kazejiyu.ekumi.ide.history.internal;
 import org.assertj.core.api.WithAssertions;
 import org.eclipse.e4.core.contexts.EclipseContextFactory;
 import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.eclipse.e4.core.services.events.IEventBroker;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 
 import fr.kazejiyu.ekumi.ide.history.PersistedHistory;
+import fr.kazejiyu.ekumi.tests.common.mock.MockitoExtension;
 
 @Tag("requires-Eclipse-runtime")
+@ExtendWith(MockitoExtension.class)
 @DisplayName("A WorkspaceHistoryCreationFunction")
 public class WorkspaceHistoryCreationFunctionTest implements WithAssertions {
 
@@ -19,13 +24,23 @@ public class WorkspaceHistoryCreationFunctionTest implements WithAssertions {
 	private IEclipseContext context;
 	
 	@BeforeEach
-	void createService() {
+	void createService(@Mock IEventBroker broker) {
 		service = new WorkspaceHistoryCreationFunction();
 		context = EclipseContextFactory.create();
+		
+		// Needed by the PersistedHistory instance created by the service
+		context.set(IEventBroker.class, broker);
 	}
 	
 	@Test @DisplayName("computes a new History instance")
 	void computes_a_new_History_instance() {
+		Object history = service.compute(context, "");
+		assertThat(history).isInstanceOf(PersistedHistory.class);
+	}
+	
+	@Test @DisplayName("does not throw when the IEventBroker cannot be found")
+	void does_not_throw_when_the_IEventBroker_cannot_be_found() {
+		context.remove(IEventBroker.class);
 		Object history = service.compute(context, "");
 		assertThat(history).isInstanceOf(PersistedHistory.class);
 	}

--- a/tests/fr.kazejiyu.ekumi.ide.test/src/fr/kazejiyu/ekumi/ide/internal/lock/LockFolderFileTest.java
+++ b/tests/fr.kazejiyu.ekumi.ide.test/src/fr/kazejiyu/ekumi/ide/internal/lock/LockFolderFileTest.java
@@ -1,0 +1,77 @@
+package fr.kazejiyu.ekumi.ide.internal.lock;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.assertj.core.api.WithAssertions;
+import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.emf.common.util.URI;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("requires-Eclipse-runtime")
+@DisplayName("A LockFolder file")
+public class LockFolderFileTest implements WithAssertions {
+	
+	private final static String uri = "platform:/meta/fr.kazejiyu.ekumi.ide.test/";
+	
+	private URI folderURI;
+	
+	private Path lockFile;
+	
+	private LockFolderFile lock;
+	
+	@BeforeEach
+	private void createURI() throws MalformedURLException, URISyntaxException, IOException {
+		folderURI = URI.createURI(uri);
+		lockFile = Paths.get(FileLocator.resolve(new URL(folderURI.appendSegment(".lock").toString())).toURI());
+		lock = new LockFolderFile(folderURI);
+	}
+	
+	@AfterEach
+	private void deleteLockFile() throws IOException {
+		Files.deleteIfExists(lockFile);
+	}
+	
+	@Nested @DisplayName("When instantiated")
+	class WhenInstantiated {
+		
+		@Test @DisplayName("creates a .lock file in given directory")
+		void creates_a_lock_file_in_given_directory() {
+			assertThat(lockFile).exists();
+		}
+		
+		@Nested @DisplayName("with a null URI")
+		class WithANullURI {
+			
+			@Test @DisplayName("throws an IOException")
+			void throws_an_IOException() {
+				assertThatIOException().isThrownBy(() -> 
+					new LockFolderFile(null)
+				);
+			}
+			
+		}
+	}
+	
+	@Nested @DisplayName("When closed")
+	class WhenClosed {
+		
+		@Test @DisplayName("deletes the .lock file")
+		void deletes_the_lock_file() throws IOException {
+			lock.close();
+			assertThat(lockFile).doesNotExist();
+		}
+		
+	}
+
+}


### PR DESCRIPTION
Update the view when an execution:
 - is launched
 - is updated

Add a new `fr.kazejiyu.ekumi.ide.events` plug-in that provides event topic constants. These constants can be used to subscribe to the E4 event system.

There is a little bug, though: when the viewer is updated the icons are not displayed on the view items. The cause of the issue is probably that I do not update the TreeViewer properly (see [ExecutionHistoryView.java](https://github.com/KazeJiyu/ekumi/pull/22/files#diff-c8cb25c0593630200f59c939b4634eefR97)).

![image](https://user-images.githubusercontent.com/25926433/50576662-fb517600-0e16-11e9-8d45-fce3991de360.png)

Since the implementation of the view will likely change in the future I won't fix the issue for the moment.