### PR TITLE
Set up basic logging facility

### DIFF
--- a/bundles/fr.kazejiyu.ekumi.core/src-gen/fr/kazejiyu/ekumi/core/ekumi/impl/ActivityImpl.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src-gen/fr/kazejiyu/ekumi/core/ekumi/impl/ActivityImpl.java
@@ -371,18 +371,8 @@ public abstract class ActivityImpl extends IdentifiableImpl implements Activity 
 	 * @generated NOT
 	 */
 	public void run(Context context) {
-		//		context.events().started(this);
-		//		
-		//		setStatus(RUNNING);s
-		//		doRun();
-		//		
-		//		if (status == SUCCEEDED)
-		//			context.events().finished(this);
-		//		else if (status == FAILED)
-		//			context.events().failed(this);
-
-		// TODO: implement this method
-		// Ensure that you remove @generated or mark it @generated NOT
+		// TODO: implement this method in sub classes
+		// so that this one can be abstract
 		throw new UnsupportedOperationException();
 	}
 

--- a/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/EKumiPlugin.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/EKumiPlugin.java
@@ -7,8 +7,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Plugin;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.emf.common.util.URI;
-import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 
 import fr.kazejiyu.ekumi.core.exceptions.EKumiRuntimeException;
@@ -18,7 +20,7 @@ import fr.kazejiyu.ekumi.core.exceptions.EKumiRuntimeException;
  * 
  * @author Emmanuel CHEBBI
  */
-public class EKumiPlugin implements BundleActivator {
+public class EKumiPlugin extends Plugin {
 	
 	public static final String ID = "fr.kazejiyu.ekumi.core";
 	
@@ -68,7 +70,7 @@ public class EKumiPlugin implements BundleActivator {
 	 * Returns the location of the state directory for this bundle under <i>.metadata/.plugins/</i>.
 	 * @return the location of the state directory for this bundle under <i>.metadata/.plugins/</i>
 	 */
-	public static Path getStateLocation() {
+	public static Path getStateLocationPath() {
 		try {
 			return Paths.get(FileLocator.resolve(new URL(getStateLocationURI().toString())).toURI());
 			
@@ -76,6 +78,48 @@ public class EKumiPlugin implements BundleActivator {
 			// Should never happen
 			throw new EKumiRuntimeException("An unexpected error occurred while resolving the state location of " + ID, e);
 		}
+	}
+	
+	/**
+	 * Logs a message for info or debugging purposes.
+	 * 
+	 * @param message
+	 * 			The message to log.
+	 */
+	public static void debug(String message) {
+		getDefault().getLog().log(new Status(IStatus.INFO, ID, message));
+	}
+	
+	/**
+	 * Logs a message for warning the user.
+	 * 
+	 * @param message
+	 * 			The message to log.
+	 */
+	public static void warn(String message) {
+		getDefault().getLog().log(new Status(IStatus.WARNING, ID, message));
+	}
+	
+	/**
+	 * Logs an error.
+	 * 
+	 * @param message
+	 * 			The error message.
+	 */
+	public static void error(String message) {
+		getDefault().getLog().log(new Status(IStatus.ERROR, ID, message));
+	}
+	
+	/**
+	 * Logs an Exception.
+	 * 
+	 * @param e
+	 * 			The exception to log.
+	 * @param message
+	 * 			The error message.
+	 */
+	public static void error(Exception e, String message) {
+		getDefault().getLog().log(new Status(IStatus.ERROR, ID, message, e));
 	}
 
 }

--- a/bundles/fr.kazejiyu.ekumi.datatypes/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.ekumi.datatypes/META-INF/MANIFEST.MF
@@ -6,3 +6,4 @@ Bundle-Version: 0.1.0
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: fr.kazejiyu.ekumi.core;bundle-version="0.1.0"
 Bundle-Vendor: Emmanuel CHEBBI
+Automatic-Module-Name: fr.kazejiyu.ekumi.datatypes

--- a/bundles/fr.kazejiyu.ekumi.datatypes/plugin.xml
+++ b/bundles/fr.kazejiyu.ekumi.datatypes/plugin.xml
@@ -4,7 +4,7 @@
    <extension
          point="fr.kazejiyu.ekumi.core.datatypes">
       <datatype
-            class="fr.kazejiyu.ekumi.datatypes.String"
+            class="fr.kazejiyu.ekumi.datatypes.StringType"
             name="fr.kazejiyu.ekumi.datatypes.string">
       </datatype>
       <datatype
@@ -12,22 +12,4 @@
             name="fr.kazejiyu.ekumi.datatypes.double">
       </datatype>
    </extension>
-   <extension
-         point="fr.kazejiyu.ekumi.core.catalogs">
-      <category
-            id="fr.kazejiyu.ekumi.datatypes.category1"
-            name="category1"
-            parent="fr.kazejiyu.ekumi.datatypes.catalog1">
-      </category>
-      <category
-            id="fr.kazejiyu.ekumi.datatypes.category2"
-            name="category2"
-            parent="fr.kazejiyu.ekumi.datatypes.category1">
-      </category>
-      <catalog
-            id="fr.kazejiyu.ekumi.datatypes.catalog1"
-            name="Catalog 1">
-      </catalog>
-   </extension>
-
 </plugin>

--- a/bundles/fr.kazejiyu.ekumi.debug/src/fr/kazejiyu/ekumi/debug/RunWorkflow.java
+++ b/bundles/fr.kazejiyu.ekumi.debug/src/fr/kazejiyu/ekumi/debug/RunWorkflow.java
@@ -33,9 +33,10 @@ public final class RunWorkflow extends LaunchConfigurationDelegate {
 	public void launch(ILaunchConfiguration configuration, String mode, ILaunch launch, IProgressMonitor monitor) throws CoreException {
 		String uri = configuration.getAttribute(EKumiRunConfiguration.EKUMI_MODEL_URI, "");
 		
-		if (uri.isEmpty())
-			// TODO log error
+		if (uri.isEmpty()) {
+			EKumiPlugin.error("Unable to launch the workflow: the model URI is empty."); 
 			return;
+		}
 		
 		ResourceSet resourceSet = new ResourceSetImpl();
 		Resource resource = resourceSet.createResource(URI.createURI(uri));
@@ -56,8 +57,7 @@ public final class RunWorkflow extends LaunchConfigurationDelegate {
 			execution.start();
 			
 		} catch (IOException e) {
-			// TODO Process exception properly
-			e.printStackTrace();
+			EKumiPlugin.error(e, "An error occurred while executing " + uri);
 		}
 	}
 

--- a/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/catalog/internal/ExtensionToCatalogsAdapter.java
+++ b/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/catalog/internal/ExtensionToCatalogsAdapter.java
@@ -150,7 +150,8 @@ class ExtensionToCatalogsAdapter {
 			
 			// still null: parent cannot be resolved
 			if (parent == null) {
-				// TODO [Log] A warning should be logged here
+				EKumiPlugin.warn("Unable to resolve the parent of the category with id '" + template.id + "'. Item will be ignored.");
+				
 				unresolvableElements.add(template.id);
 				unresolvableElements.add(template.parentId);
 

--- a/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/history/PersistedHistory.java
+++ b/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/history/PersistedHistory.java
@@ -21,6 +21,7 @@ import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
 
+import fr.kazejiyu.ekumi.EKumiPlugin;
 import fr.kazejiyu.ekumi.core.ekumi.EkumiPackage;
 import fr.kazejiyu.ekumi.core.ekumi.Execution;
 import fr.kazejiyu.ekumi.core.ekumi.History;
@@ -95,8 +96,7 @@ public class PersistedHistory extends HistoryImpl {
 			return (Execution) resource.getContents().get(0);
 			
 		} catch (Exception e) {
-			// TODO Proper logging
-			e.printStackTrace();
+			EKumiPlugin.error(e, "Unable to load an Execution from " + file.getAbsolutePath());
 			return null;
 		}
 	}

--- a/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/history/PostEventOnExecutionChange.java
+++ b/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/history/PostEventOnExecutionChange.java
@@ -10,6 +10,7 @@ import java.nio.file.Path;
 import org.apache.commons.io.monitor.FileAlterationListenerAdaptor;
 import org.eclipse.e4.core.services.events.IEventBroker;
 
+import fr.kazejiyu.ekumi.EKumiPlugin;
 import fr.kazejiyu.ekumi.core.ekumi.Execution;
 import fr.kazejiyu.ekumi.ide.events.EKumiEvents;
 
@@ -49,13 +50,10 @@ class PostEventOnExecutionChange extends FileAlterationListenerAdaptor {
 	private void process(File file, String event) {
 		try {
     		Execution execution = load(file);
-    		System.out.println("POSTING " + event + " TO " + bus);
     		bus.post(event, execution);
-    		System.out.println("POSTED");
     		
     	} catch (Exception e) {
-    		// TODO Proper logging
-    		e.printStackTrace();
+    		EKumiPlugin.error(e, "An error occurred while processing changes in " + (file == null ? file : file.getAbsolutePath()));
     	}
 	}
     

--- a/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/history/internal/WorkspaceHistoryCreationFunction.java
+++ b/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/history/internal/WorkspaceHistoryCreationFunction.java
@@ -30,13 +30,12 @@ public class WorkspaceHistoryCreationFunction implements IContextFunction {
 	
 	@Override
 	public Object compute(IEclipseContext context, String contextKey) {
-		PersistedHistory history = new PersistedHistory(EKumiPlugin.getStateLocation().resolve("executions"));
+		PersistedHistory history = new PersistedHistory(EKumiPlugin.getStateLocationPath().resolve("executions"));
 		try {
 			history.notifyOnChange(context.get(IEventBroker.class));
 			
 		} catch (Exception e) {
-			// TODO Properly log error
-			e.printStackTrace();
+			EKumiPlugin.error(e, "An error occurred while computing the history of executions. Won't be able to listen for changes in real time.");
 		}
 		ContextInjectionFactory.inject(history, context);
 		return history;


### PR DESCRIPTION
One can now log with EKumiPlugin.[debug|warn|error] static methods.

This is not an ideal solution, but it is still better than prints to the standard or error streams and will be sufficient for the moment.