### PR TITLE
Fix extension schemas

### DIFF
--- a/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/EKumiPlugin.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/EKumiPlugin.java
@@ -25,13 +25,13 @@ public class EKumiPlugin extends Plugin {
 	public static final String ID = "fr.kazejiyu.ekumi.core";
 	
 	/** ID of the 'catalogs' extension point */
-	public static final String CATALOGS_EXTENSION_ID = "fr.kazejiyu.ekumi.core.catalogs";
+	public static final String CATALOGS_EXTENSION_ID = "fr.kazejiyu.ekumi.model.catalogs";
 	
 	/** ID of the 'datatypes' extension point */
-	public static final String DATATYPES_EXTENSION_ID = "fr.kazejiyu.ekumi.core.datatypes";
+	public static final String DATATYPES_EXTENSION_ID = "fr.kazejiyu.ekumi.model.datatypes";
 	
 	/** ID of the 'languages' extension point */
-	public static final String LANGUAGES_EXTENSION_ID = "fr.kazejiyu.ekumi.core.languages";
+	public static final String LANGUAGES_EXTENSION_ID = "fr.kazejiyu.ekumi.model.languages";
 
 	/** URI of the plug-in's corresponding folder under the .metadata/.plugins directory */
 	private static final URI STATE_LOCATION_URI = URI.createURI("platform:/meta/" + ID + "/");

--- a/bundles/fr.kazejiyu.ekumi.model/schema/catalogs.exsd
+++ b/bundles/fr.kazejiyu.ekumi.model/schema/catalogs.exsd
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Schema file written by PDE -->
-<schema targetNamespace="fr.kazejiyu.ekumi.core" xmlns="http://www.w3.org/2001/XMLSchema">
+<schema targetNamespace="fr.kazejiyu.ekumi.model" xmlns="http://www.w3.org/2001/XMLSchema">
 <annotation>
       <appinfo>
-         <meta.schema plugin="fr.kazejiyu.ekumi.core" id="catalogs" name="Catalogs"/>
+         <meta.schema plugin="fr.kazejiyu.ekumi.model" id="catalogs" name="Catalogs"/>
       </appinfo>
       <documentation>
          Used to define new catalogs, which are a way to bundle and organize templates of Activities.
@@ -83,7 +83,7 @@ A Catalog makes easier to share and reuse Activities.
 Typically, in a tree view, a sub-category would be displayed as a child of the parent category.
                </documentation>
                <appinfo>
-                  <meta.attribute kind="identifier" basedOn="fr.kazejiyu.ekumi.core.catalogs/category/@id,fr.kazejiyu.ekumi.core.catalogs/catalog/@id"/>
+                  <meta.attribute kind="identifier" basedOn="fr.kazejiyu.ekumi.model.catalogs/category/@id,fr.kazejiyu.ekumi.model.catalogs/catalog/@id"/>
                </appinfo>
             </annotation>
          </attribute>
@@ -172,7 +172,7 @@ Such a model file likely ends with &apos;.ekumi&apos; and is located in the &apo
                   Id of the category to which the Activity belongs.
                </documentation>
                <appinfo>
-                  <meta.attribute kind="identifier" basedOn="fr.kazejiyu.ekumi.core.catalogs/category/@id"/>
+                  <meta.attribute kind="identifier" basedOn="fr.kazejiyu.ekumi.model.catalogs/category/@id"/>
                </appinfo>
             </annotation>
          </attribute>

--- a/bundles/fr.kazejiyu.ekumi.model/schema/datatypes.exsd
+++ b/bundles/fr.kazejiyu.ekumi.model/schema/datatypes.exsd
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Schema file written by PDE -->
-<schema targetNamespace="fr.kazejiyu.ekumi.core" xmlns="http://www.w3.org/2001/XMLSchema">
+<schema targetNamespace="fr.kazejiyu.ekumi.model" xmlns="http://www.w3.org/2001/XMLSchema">
 <annotation>
       <appinfo>
-         <meta.schema plugin="fr.kazejiyu.ekumi.core" id="datatypes" name="DataTypes"/>
+         <meta.schema plugin="fr.kazejiyu.ekumi.model" id="datatypes" name="DataTypes"/>
       </appinfo>
       <documentation>
          Used to define new types of data. A data can be either inputs or outputs.
@@ -62,7 +62,7 @@
                   
                </documentation>
                <appinfo>
-                  <meta.attribute kind="java" basedOn=":fr.kazejiyu.ekumi.core.datatypes.DataType"/>
+                  <meta.attribute kind="java" basedOn=":fr.kazejiyu.ekumi.model.datatypes.DataType"/>
                </appinfo>
             </annotation>
          </attribute>

--- a/bundles/fr.kazejiyu.ekumi.model/schema/languages.exsd
+++ b/bundles/fr.kazejiyu.ekumi.model/schema/languages.exsd
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Schema file written by PDE -->
-<schema targetNamespace="fr.kazejiyu.ekumi.core" xmlns="http://www.w3.org/2001/XMLSchema">
+<schema targetNamespace="fr.kazejiyu.ekumi.model" xmlns="http://www.w3.org/2001/XMLSchema">
 <annotation>
       <appinfo>
-         <meta.schema plugin="fr.kazejiyu.ekumi.core" id="languages" name="Languages"/>
+         <meta.schema plugin="fr.kazejiyu.ekumi.model" id="languages" name="Languages"/>
       </appinfo>
       <documentation>
          Used to define a new programming language that can then be used to implement a task&apos;s behavior.
@@ -64,7 +64,7 @@ A programming language is represented by an instance of ScriptingLanguage, which
                   The class that defines the new scripting language.
                </documentation>
                <appinfo>
-                  <meta.attribute kind="java" basedOn=":fr.kazejiyu.ekumi.core.languages.ScriptingLanguage"/>
+                  <meta.attribute kind="java" basedOn=":fr.kazejiyu.ekumi.model.languages.ScriptingLanguage"/>
                </appinfo>
             </annotation>
          </attribute>


### PR DESCRIPTION
Extensions schemas have not been properly updated and still reference the previous `fr.kazejiyu.ekumi.core` plug-in. This prevents the extension from being taken into account and is fixed by this PR.