### PR TITLE
Disable Codecov's patch status

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,3 @@
+coverage:
+  status:
+    patch: off


### PR DESCRIPTION
This status is sometimes a bit buggy and causes the PR to have a 'failed'
status even if everything is OK.

I don't have time to tailor its behavior at the moment so let's just disable it.