### PR TITLE
Add constraints to the workflow diagram editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ target/
 
 # Folder used during tests
 /tests/fr.kazejiyu.ekumi.ide.test/rsc/PersistExecutionTest
+
+# Eclipse IDE preferences
+fr.kazejiyu.discord.rpc.integration.prefs

--- a/bundles/fr.kazejiyu.ekumi.core/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.ekumi.core/META-INF/MANIFEST.MF
@@ -16,5 +16,4 @@ Bundle-Activator: fr.kazejiyu.ekumi.EKumiPlugin
 Export-Package: fr.kazejiyu.ekumi,
  fr.kazejiyu.ekumi.core.execution,
  fr.kazejiyu.ekumi.core.execution.events.impl,
- fr.kazejiyu.ekumi.core.workflow,
  fr.kazejiyu.ekumi.core.workflow.impl

--- a/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/execution/BasicContext.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/execution/BasicContext.java
@@ -40,12 +40,12 @@ class BasicContext extends ContextImpl {
 	
 	@Override
 	public Variable get(String name) {
-		Optional<Variable> maybeVariable = find(name);
+		Optional<Variable> variable = find(name);
 		
-		if (! maybeVariable.isPresent())
+		if (! variable.isPresent())
 			throw new VariableNotFoundException("No variable named " + name + " exists in this context");
 		
-		return maybeVariable.get();
+		return variable.get();
 	}
 
 	@Override

--- a/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/spec/impl/BasicExternalTask.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/spec/impl/BasicExternalTask.java
@@ -1,0 +1,30 @@
+package fr.kazejiyu.ekumi.core.spec.impl;
+
+import org.eclipse.emf.ecore.util.EcoreUtil;
+
+import fr.kazejiyu.ekumi.model.spec.Node;
+import fr.kazejiyu.ekumi.model.spec.impl.ExternalTaskImpl;
+
+public class BasicExternalTask extends ExternalTaskImpl {
+	
+	@Override
+	public boolean canPrecede() {
+		return getSuccessors().isEmpty();
+	}
+	
+	@Override
+	public boolean canPrecede(Node node) {
+		return canPrecede() && ! EcoreUtil.equals(this, node);
+	}
+	
+	@Override
+	public boolean canSucceed() {
+		return getPredecessors().isEmpty();
+	}
+	
+	@Override
+	public boolean canSucceed(Node node) {
+		return canSucceed() && ! EcoreUtil.equals(this, node); 
+	}
+
+}

--- a/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/spec/impl/BasicMultiChoice.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/spec/impl/BasicMultiChoice.java
@@ -1,0 +1,30 @@
+package fr.kazejiyu.ekumi.core.spec.impl;
+
+import org.eclipse.emf.ecore.util.EcoreUtil;
+
+import fr.kazejiyu.ekumi.model.spec.Node;
+import fr.kazejiyu.ekumi.model.spec.impl.MultiChoiceImpl;
+
+public class BasicMultiChoice extends MultiChoiceImpl {
+	
+	@Override
+	public boolean canPrecede() {
+		return true;
+	}
+
+	@Override
+	public boolean canPrecede(Node node) {
+		return ! EcoreUtil.equals(this, node);
+	}
+	
+	@Override
+	public boolean canSucceed() {
+		return getPredecessors().isEmpty();
+	}
+	
+	@Override
+	public boolean canSucceed(Node node) {
+		return canSucceed() && ! EcoreUtil.equals(this, node); 
+	}
+
+}

--- a/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/spec/impl/BasicParallelSplit.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/spec/impl/BasicParallelSplit.java
@@ -1,0 +1,31 @@
+package fr.kazejiyu.ekumi.core.spec.impl;
+
+import org.eclipse.emf.ecore.util.EcoreUtil;
+
+import fr.kazejiyu.ekumi.model.spec.Node;
+import fr.kazejiyu.ekumi.model.spec.impl.ParallelSplitImpl;
+
+public class BasicParallelSplit extends ParallelSplitImpl {
+	
+	@Override
+	public boolean canPrecede() {
+		return true;
+	}
+	
+	@Override
+	public boolean canPrecede(Node node) {
+		return ! getSuccessors().contains(node) 
+			&& ! EcoreUtil.equals(this, node);
+	}
+	
+	@Override
+	public boolean canSucceed() {
+		return getPredecessors().isEmpty();
+	}
+	
+	@Override
+	public boolean canSucceed(Node node) {
+		return canSucceed() && ! EcoreUtil.equals(this, node);
+	}
+
+}

--- a/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/spec/impl/BasicSimpleMerge.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/spec/impl/BasicSimpleMerge.java
@@ -1,0 +1,31 @@
+package fr.kazejiyu.ekumi.core.spec.impl;
+
+import org.eclipse.emf.ecore.util.EcoreUtil;
+
+import fr.kazejiyu.ekumi.model.spec.Node;
+import fr.kazejiyu.ekumi.model.spec.impl.SimpleMergeImpl;
+
+public class BasicSimpleMerge extends SimpleMergeImpl {
+	
+	@Override
+	public boolean canPrecede() {
+		return getSuccessors().isEmpty();
+	}
+	
+	@Override
+	public boolean canPrecede(Node node) {
+		return canPrecede() && ! EcoreUtil.equals(this, node);
+	}
+	
+	@Override
+	public boolean canSucceed() {
+		return true;
+	}
+	
+	@Override
+	public boolean canSucceed(Node node) {
+		return ! getPredecessors().contains(node)
+			&& ! EcoreUtil.equals(this, node);
+	}
+
+}

--- a/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/spec/impl/BasicSpecFactory.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/spec/impl/BasicSpecFactory.java
@@ -2,7 +2,13 @@ package fr.kazejiyu.ekumi.core.spec.impl;
 
 import org.eclipse.emf.ecore.EFactory;
 
+import fr.kazejiyu.ekumi.model.spec.ExternalTask;
+import fr.kazejiyu.ekumi.model.spec.MultiChoice;
+import fr.kazejiyu.ekumi.model.spec.ParallelSplit;
+import fr.kazejiyu.ekumi.model.spec.SimpleMerge;
 import fr.kazejiyu.ekumi.model.spec.SpecPackage;
+import fr.kazejiyu.ekumi.model.spec.Start;
+import fr.kazejiyu.ekumi.model.spec.Synchronization;
 import fr.kazejiyu.ekumi.model.spec.impl.SpecFactoryImpl;
 
 /**
@@ -10,4 +16,34 @@ import fr.kazejiyu.ekumi.model.spec.impl.SpecFactoryImpl;
  */
 public class BasicSpecFactory extends SpecFactoryImpl implements EFactory {
 
+	@Override
+	public Start createStart() {
+		return new BasicStart();
+	}
+	
+	@Override
+	public ExternalTask createExternalTask() {
+		return new BasicExternalTask();
+	}
+
+	@Override
+	public ParallelSplit createParallelSplit() {
+		return new BasicParallelSplit();
+	}
+	
+	@Override
+	public Synchronization createSynchronization() {
+		return new BasicSynchronization();
+	}
+
+	@Override
+	public MultiChoice createMultiChoice() {
+		return new BasicMultiChoice();
+	}
+
+	@Override
+	public SimpleMerge createSimpleMerge() {
+		return new BasicSimpleMerge();
+	}
+	
 }

--- a/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/spec/impl/BasicStart.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/spec/impl/BasicStart.java
@@ -1,0 +1,30 @@
+package fr.kazejiyu.ekumi.core.spec.impl;
+
+import org.eclipse.emf.ecore.util.EcoreUtil;
+
+import fr.kazejiyu.ekumi.model.spec.Node;
+import fr.kazejiyu.ekumi.model.spec.impl.StartImpl;
+
+public class BasicStart extends StartImpl {
+	
+	@Override
+	public boolean canPrecede() {
+		return getSuccessors().isEmpty();
+	}
+	
+	@Override
+	public boolean canPrecede(Node node) {
+		return canPrecede() && ! EcoreUtil.equals(this, node);
+	}
+	
+	@Override
+	public boolean canSucceed() {
+		return false;
+	}
+	
+	@Override
+	public boolean canSucceed(Node node) {
+		return false;
+	}
+
+}

--- a/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/spec/impl/BasicSynchronization.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/spec/impl/BasicSynchronization.java
@@ -1,0 +1,31 @@
+package fr.kazejiyu.ekumi.core.spec.impl;
+
+import org.eclipse.emf.ecore.util.EcoreUtil;
+
+import fr.kazejiyu.ekumi.model.spec.Node;
+import fr.kazejiyu.ekumi.model.spec.impl.SynchronizationImpl;
+
+public class BasicSynchronization extends SynchronizationImpl {
+	
+	@Override
+	public boolean canPrecede() {
+		return getSuccessors().isEmpty();
+	}
+	
+	@Override
+	public boolean canPrecede(Node node) {
+		return canPrecede() && ! EcoreUtil.equals(this, node); 
+	}
+	
+	@Override
+	public boolean canSucceed() {
+		return true;
+	}
+	
+	@Override
+	public boolean canSucceed(Node node) {
+		return ! getPredecessors().contains(node)
+			&& ! EcoreUtil.equals(this, node);
+	}
+
+}

--- a/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/workflow/package-info.java
+++ b/bundles/fr.kazejiyu.ekumi.core/src/fr/kazejiyu/ekumi/core/workflow/package-info.java
@@ -1,4 +1,0 @@
-/**
- * @author Emmanuel CHEBBI
- */
-package fr.kazejiyu.ekumi.core.workflow;

--- a/bundles/fr.kazejiyu.ekumi.model/model/ekumi.aird
+++ b/bundles/fr.kazejiyu.ekumi.model/model/ekumi.aird
@@ -3269,11 +3269,27 @@
               <styles xmi:type="notation:FontStyle" xmi:id="_StuCkxEmEemMnZeZ1_LMMg" fontName="Segoe UI" fontHeight="8"/>
               <layoutConstraint xmi:type="notation:Location" xmi:id="_StuClBEmEemMnZeZ1_LMMg"/>
             </children>
+            <children xmi:type="notation:Node" xmi:id="_undFADwREemGKsgo50MVbw" type="3010" element="_ukU4gDwREemGKsgo50MVbw">
+              <styles xmi:type="notation:FontStyle" xmi:id="_undFATwREemGKsgo50MVbw" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_undFAjwREemGKsgo50MVbw"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_1Hse4DwREemGKsgo50MVbw" type="3010" element="_1HaLADwREemGKsgo50MVbw">
+              <styles xmi:type="notation:FontStyle" xmi:id="_1Hse4TwREemGKsgo50MVbw" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_1Hse4jwREemGKsgo50MVbw"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_gnsW0DwXEemGKsgo50MVbw" type="3010" element="_gngwoDwXEemGKsgo50MVbw">
+              <styles xmi:type="notation:FontStyle" xmi:id="_gnsW0TwXEemGKsgo50MVbw" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_gnsW0jwXEemGKsgo50MVbw"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_kyXAcDwXEemGKsgo50MVbw" type="3010" element="_kyKMIDwXEemGKsgo50MVbw">
+              <styles xmi:type="notation:FontStyle" xmi:id="_kyXAcTwXEemGKsgo50MVbw" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_kyXAcjwXEemGKsgo50MVbw"/>
+            </children>
             <styles xmi:type="notation:SortingStyle" xmi:id="_Sts0fhEmEemMnZeZ1_LMMg"/>
             <styles xmi:type="notation:FilteringStyle" xmi:id="_Sts0fxEmEemMnZeZ1_LMMg"/>
           </children>
           <styles xmi:type="notation:ShapeStyle" xmi:id="_Sts0ehEmEemMnZeZ1_LMMg" fontName="Segoe UI" fontHeight="8" italic="true"/>
-          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Sts0exEmEemMnZeZ1_LMMg" x="668" y="162"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Sts0exEmEemMnZeZ1_LMMg" x="668" y="130" height="132"/>
         </children>
         <children xmi:type="notation:Node" xmi:id="_Sts0gBEmEemMnZeZ1_LMMg" type="2003" element="_StgAEREmEemMnZeZ1_LMMg">
           <children xmi:type="notation:Node" xmi:id="_SttbcBEmEemMnZeZ1_LMMg" type="5007"/>
@@ -3789,8 +3805,8 @@
           <styles xmi:type="notation:ConnectorStyle" xmi:id="_StziJREmEemMnZeZ1_LMMg" routing="Rectilinear"/>
           <styles xmi:type="notation:FontStyle" xmi:id="_StziJhEmEemMnZeZ1_LMMg" fontName="Segoe UI" fontHeight="8"/>
           <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_StziJxEmEemMnZeZ1_LMMg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_StziLhEmEemMnZeZ1_LMMg" id="(0.5,0.5)"/>
-          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_StziLxEmEemMnZeZ1_LMMg" id="(0.5,0.5)"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_StziLhEmEemMnZeZ1_LMMg" id="(0.5,0.6230769230769231)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_StziLxEmEemMnZeZ1_LMMg" id="(0.5,0.6230769230769231)"/>
         </edges>
         <edges xmi:type="notation:Edge" xmi:id="_lv9nkBEqEemMnZeZ1_LMMg" type="4001" element="_lv8ZdhEqEemMnZeZ1_LMMg" source="_Sts0gBEmEemMnZeZ1_LMMg" target="_SttbghEmEemMnZeZ1_LMMg">
           <children xmi:type="notation:Node" xmi:id="_lv9nlBEqEemMnZeZ1_LMMg" type="6001">
@@ -4008,7 +4024,7 @@
     <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_StfZBREmEemMnZeZ1_LMMg" name="Node" tooltipText="" outgoingEdges="_StqYNxEmEemMnZeZ1_LMMg" incomingEdges="_StpKDhEmEemMnZeZ1_LMMg _StpxHhEmEemMnZeZ1_LMMg _StqYJhEmEemMnZeZ1_LMMg _StqYNxEmEemMnZeZ1_LMMg" width="12" height="10">
       <target xmi:type="ecore:EClass" href="spec.ecore#//Node"/>
       <semanticElements xmi:type="ecore:EClass" href="spec.ecore#//Node"/>
-      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_StfZBhEmEemMnZeZ1_LMMg" iconPath="/org.eclipse.emf.ecoretools.design/icons/full/obj16/EClass_abstract.gif" borderSize="1" borderSizeComputationExpression="1" borderColor="125,125,125" backgroundStyle="Liquid" foregroundColor="228,228,228">
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_7MO0PzwREemGKsgo50MVbw" iconPath="/org.eclipse.emf.ecoretools.design/icons/full/obj16/EClass_abstract.gif" borderSize="1" borderSizeComputationExpression="1" borderColor="125,125,125" backgroundStyle="Liquid" foregroundColor="228,228,228">
         <labelFormat>italic</labelFormat>
         <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@conditionnalStyles.1/@style"/>
       </ownedStyle>
@@ -4027,6 +4043,40 @@
         <semanticElements xmi:type="ecore:EOperation" href="spec.ecore#//Node/canSucceed"/>
         <semanticElements xmi:type="ecore:EParameter" href="spec.ecore#//Node/canSucceed/node"/>
         <ownedStyle xmi:type="diagram:BundledImage" uid="_StlfohEmEemMnZeZ1_LMMg" labelAlignment="LEFT">
+          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='Operation']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='Operation']"/>
+      </ownedElements>
+      <ownedElements xmi:type="diagram:DNodeListElement" uid="_ukU4gDwREemGKsgo50MVbw" name="precedes(successor Node) : Boolean" tooltipText="precedes(successor) : Boolean">
+        <target xmi:type="ecore:EOperation" href="spec.ecore#//Node/precedes"/>
+        <semanticElements xmi:type="ecore:EOperation" href="spec.ecore#//Node/precedes"/>
+        <semanticElements xmi:type="ecore:EParameter" href="spec.ecore#//Node/precedes/successor"/>
+        <ownedStyle xmi:type="diagram:BundledImage" uid="_ukWGoDwREemGKsgo50MVbw" labelAlignment="LEFT">
+          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='Operation']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='Operation']"/>
+      </ownedElements>
+      <ownedElements xmi:type="diagram:DNodeListElement" uid="_1HaLADwREemGKsgo50MVbw" name="succeeds(predecessor Node) : Boolean" tooltipText="succeeds(predecessor) : Boolean">
+        <target xmi:type="ecore:EOperation" href="spec.ecore#//Node/succeeds"/>
+        <semanticElements xmi:type="ecore:EOperation" href="spec.ecore#//Node/succeeds"/>
+        <semanticElements xmi:type="ecore:EParameter" href="spec.ecore#//Node/succeeds/predecessor"/>
+        <ownedStyle xmi:type="diagram:BundledImage" uid="_1HcAMDwREemGKsgo50MVbw" labelAlignment="LEFT">
+          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='Operation']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='Operation']"/>
+      </ownedElements>
+      <ownedElements xmi:type="diagram:DNodeListElement" uid="_gngwoDwXEemGKsgo50MVbw" name="canPrecede() : Boolean" tooltipText="canPrecede() : Boolean">
+        <target xmi:type="ecore:EOperation" href="spec.ecore#//Node/canPrecede.1"/>
+        <semanticElements xmi:type="ecore:EOperation" href="spec.ecore#//Node/canPrecede.1"/>
+        <ownedStyle xmi:type="diagram:BundledImage" uid="_gnhXsDwXEemGKsgo50MVbw" labelAlignment="LEFT">
+          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='Operation']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='Operation']"/>
+      </ownedElements>
+      <ownedElements xmi:type="diagram:DNodeListElement" uid="_kyKMIDwXEemGKsgo50MVbw" name="canSucceed() : Boolean" tooltipText="canSucceed() : Boolean">
+        <target xmi:type="ecore:EOperation" href="spec.ecore#//Node/canSucceed.1"/>
+        <semanticElements xmi:type="ecore:EOperation" href="spec.ecore#//Node/canSucceed.1"/>
+        <ownedStyle xmi:type="diagram:BundledImage" uid="_kyKzMDwXEemGKsgo50MVbw" labelAlignment="LEFT">
           <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='Operation']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='Operation']"/>

--- a/bundles/fr.kazejiyu.ekumi.model/model/ekumi.genmodel
+++ b/bundles/fr.kazejiyu.ekumi.model/model/ekumi.genmodel
@@ -249,6 +249,14 @@
       <genOperations ecoreOperation="spec.ecore#//Node/canSucceed">
         <genParameters ecoreParameter="spec.ecore#//Node/canSucceed/node"/>
       </genOperations>
+      <genOperations ecoreOperation="spec.ecore#//Node/precedes">
+        <genParameters ecoreParameter="spec.ecore#//Node/precedes/successor"/>
+      </genOperations>
+      <genOperations ecoreOperation="spec.ecore#//Node/succeeds">
+        <genParameters ecoreParameter="spec.ecore#//Node/succeeds/predecessor"/>
+      </genOperations>
+      <genOperations ecoreOperation="spec.ecore#//Node/canPrecede.1"/>
+      <genOperations ecoreOperation="spec.ecore#//Node/canSucceed.1"/>
     </genClasses>
     <genClasses image="false" ecoreClass="spec.ecore#//ConditionalDivergence"/>
     <genClasses ecoreClass="spec.ecore#//ConditionalRoot">

--- a/bundles/fr.kazejiyu.ekumi.model/model/spec.ecore
+++ b/bundles/fr.kazejiyu.ekumi.model/model/spec.ecore
@@ -103,6 +103,14 @@
     <eOperations name="canSucceed" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Boolean">
       <eParameters name="node" eType="#//Node"/>
     </eOperations>
+    <eOperations name="precedes" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Boolean">
+      <eParameters name="successor" eType="#//Node"/>
+    </eOperations>
+    <eOperations name="succeeds" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Boolean">
+      <eParameters name="predecessor" eType="#//Node"/>
+    </eOperations>
+    <eOperations name="canPrecede" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Boolean"/>
+    <eOperations name="canSucceed" eType="ecore:EDataType http://www.eclipse.org/emf/2003/XMLType#//Boolean"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="successors" upperBound="-1"
         eType="#//Node" eOpposite="#//Node/predecessors"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="predecessors" upperBound="-1"

--- a/bundles/fr.kazejiyu.ekumi.model/src-gen/fr/kazejiyu/ekumi/model/spec/Node.java
+++ b/bundles/fr.kazejiyu.ekumi.model/src-gen/fr/kazejiyu/ekumi/model/spec/Node.java
@@ -49,6 +49,12 @@ public interface Node extends EObject {
 
 	/**
 	 * <!-- begin-user-doc -->
+	 * Returns whether the given node can be a successor of this.
+	 * 
+	 * @param node
+	 * 			The node to check.
+	 * 
+	 * @return whether the given node can be a successor of this
 	 * <!-- end-user-doc -->
 	 * @model dataType="org.eclipse.emf.ecore.xml.type.Boolean"
 	 * @generated
@@ -57,10 +63,64 @@ public interface Node extends EObject {
 
 	/**
 	 * <!-- begin-user-doc -->
+	 * Returns whether the given node can be a predecessor of this.
+	 * 
+	 * @param node
+	 * 			The node to check.
+	 * 
+	 * @return whether the given node can be a predecessor of this
 	 * <!-- end-user-doc -->
 	 * @model dataType="org.eclipse.emf.ecore.xml.type.Boolean"
 	 * @generated
 	 */
 	boolean canSucceed(Node node);
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * Returns whether the given node is a successor of this.
+	 * 
+	 * @param successor
+	 * 			The potential successor of this.
+	 * 
+	 * @return whether the given node is a successor of this 
+	 * <!-- end-user-doc -->
+	 * @model dataType="org.eclipse.emf.ecore.xml.type.Boolean"
+	 * @generated
+	 */
+	boolean precedes(Node successor);
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * Returns whether the given node is a predecessor of this.
+	 * 
+	 * @param predecessor
+	 * 			The potential predecessor of this.
+	 * 
+	 * @return whether the given node is a predecessor of this
+	 * <!-- end-user-doc -->
+	 * @model dataType="org.eclipse.emf.ecore.xml.type.Boolean"
+	 * @generated
+	 */
+	boolean succeeds(Node predecessor);
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * Returns whether this node can have a new successor.
+	 * @return whether this node can have a new successor
+	 * <!-- end-user-doc -->
+	 * @model dataType="org.eclipse.emf.ecore.xml.type.Boolean"
+	 * @generated
+	 */
+	boolean canPrecede();
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * Returns whether this node can have a new predecessor.
+	 * @return whether this node can have a new predecessor
+	 * <!-- end-user-doc -->
+	 * @model dataType="org.eclipse.emf.ecore.xml.type.Boolean"
+	 * @generated
+	 */
+	boolean canSucceed();
 
 } // Node

--- a/bundles/fr.kazejiyu.ekumi.model/src-gen/fr/kazejiyu/ekumi/model/spec/SpecPackage.java
+++ b/bundles/fr.kazejiyu.ekumi.model/src-gen/fr/kazejiyu/ekumi/model/spec/SpecPackage.java
@@ -113,13 +113,49 @@ public interface SpecPackage extends EPackage {
 	int NODE___CAN_SUCCEED__NODE = 1;
 
 	/**
+	 * The operation id for the '<em>Precedes</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int NODE___PRECEDES__NODE = 2;
+
+	/**
+	 * The operation id for the '<em>Succeeds</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int NODE___SUCCEEDS__NODE = 3;
+
+	/**
+	 * The operation id for the '<em>Can Precede</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int NODE___CAN_PRECEDE = 4;
+
+	/**
+	 * The operation id for the '<em>Can Succeed</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int NODE___CAN_SUCCEED = 5;
+
+	/**
 	 * The number of operations of the '<em>Node</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int NODE_OPERATION_COUNT = 2;
+	int NODE_OPERATION_COUNT = 6;
 
 	/**
 	 * The meta object id for the '{@link fr.kazejiyu.ekumi.model.spec.impl.StartingNodeImpl <em>Starting Node</em>}' class.
@@ -175,6 +211,42 @@ public interface SpecPackage extends EPackage {
 	 * @ordered
 	 */
 	int STARTING_NODE___CAN_SUCCEED__NODE = NODE___CAN_SUCCEED__NODE;
+
+	/**
+	 * The operation id for the '<em>Precedes</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int STARTING_NODE___PRECEDES__NODE = NODE___PRECEDES__NODE;
+
+	/**
+	 * The operation id for the '<em>Succeeds</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int STARTING_NODE___SUCCEEDS__NODE = NODE___SUCCEEDS__NODE;
+
+	/**
+	 * The operation id for the '<em>Can Precede</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int STARTING_NODE___CAN_PRECEDE = NODE___CAN_PRECEDE;
+
+	/**
+	 * The operation id for the '<em>Can Succeed</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int STARTING_NODE___CAN_SUCCEED = NODE___CAN_SUCCEED;
 
 	/**
 	 * The number of operations of the '<em>Starting Node</em>' class.
@@ -284,6 +356,42 @@ public interface SpecPackage extends EPackage {
 	 * @ordered
 	 */
 	int TASK___CAN_SUCCEED__NODE = STARTING_NODE___CAN_SUCCEED__NODE;
+
+	/**
+	 * The operation id for the '<em>Precedes</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int TASK___PRECEDES__NODE = STARTING_NODE___PRECEDES__NODE;
+
+	/**
+	 * The operation id for the '<em>Succeeds</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int TASK___SUCCEEDS__NODE = STARTING_NODE___SUCCEEDS__NODE;
+
+	/**
+	 * The operation id for the '<em>Can Precede</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int TASK___CAN_PRECEDE = STARTING_NODE___CAN_PRECEDE;
+
+	/**
+	 * The operation id for the '<em>Can Succeed</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int TASK___CAN_SUCCEED = STARTING_NODE___CAN_SUCCEED;
 
 	/**
 	 * The number of operations of the '<em>Task</em>' class.
@@ -458,6 +566,42 @@ public interface SpecPackage extends EPackage {
 	int ACTIVITY___CAN_SUCCEED__NODE = TASK___CAN_SUCCEED__NODE;
 
 	/**
+	 * The operation id for the '<em>Precedes</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int ACTIVITY___PRECEDES__NODE = TASK___PRECEDES__NODE;
+
+	/**
+	 * The operation id for the '<em>Succeeds</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int ACTIVITY___SUCCEEDS__NODE = TASK___SUCCEEDS__NODE;
+
+	/**
+	 * The operation id for the '<em>Can Precede</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int ACTIVITY___CAN_PRECEDE = TASK___CAN_PRECEDE;
+
+	/**
+	 * The operation id for the '<em>Can Succeed</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int ACTIVITY___CAN_SUCCEED = TASK___CAN_SUCCEED;
+
+	/**
 	 * The number of operations of the '<em>Activity</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -529,6 +673,42 @@ public interface SpecPackage extends EPackage {
 	 * @ordered
 	 */
 	int START___CAN_SUCCEED__NODE = NODE___CAN_SUCCEED__NODE;
+
+	/**
+	 * The operation id for the '<em>Precedes</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int START___PRECEDES__NODE = NODE___PRECEDES__NODE;
+
+	/**
+	 * The operation id for the '<em>Succeeds</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int START___SUCCEEDS__NODE = NODE___SUCCEEDS__NODE;
+
+	/**
+	 * The operation id for the '<em>Can Precede</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int START___CAN_PRECEDE = NODE___CAN_PRECEDE;
+
+	/**
+	 * The operation id for the '<em>Can Succeed</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int START___CAN_SUCCEED = NODE___CAN_SUCCEED;
 
 	/**
 	 * The number of operations of the '<em>Start</em>' class.
@@ -613,6 +793,42 @@ public interface SpecPackage extends EPackage {
 	int DIVERGENCE___CAN_SUCCEED__NODE = STARTING_NODE___CAN_SUCCEED__NODE;
 
 	/**
+	 * The operation id for the '<em>Precedes</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int DIVERGENCE___PRECEDES__NODE = STARTING_NODE___PRECEDES__NODE;
+
+	/**
+	 * The operation id for the '<em>Succeeds</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int DIVERGENCE___SUCCEEDS__NODE = STARTING_NODE___SUCCEEDS__NODE;
+
+	/**
+	 * The operation id for the '<em>Can Precede</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int DIVERGENCE___CAN_PRECEDE = STARTING_NODE___CAN_PRECEDE;
+
+	/**
+	 * The operation id for the '<em>Can Succeed</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int DIVERGENCE___CAN_SUCCEED = STARTING_NODE___CAN_SUCCEED;
+
+	/**
 	 * The number of operations of the '<em>Divergence</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -693,6 +909,42 @@ public interface SpecPackage extends EPackage {
 	 * @ordered
 	 */
 	int PARALLEL_SPLIT___CAN_SUCCEED__NODE = DIVERGENCE___CAN_SUCCEED__NODE;
+
+	/**
+	 * The operation id for the '<em>Precedes</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int PARALLEL_SPLIT___PRECEDES__NODE = DIVERGENCE___PRECEDES__NODE;
+
+	/**
+	 * The operation id for the '<em>Succeeds</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int PARALLEL_SPLIT___SUCCEEDS__NODE = DIVERGENCE___SUCCEEDS__NODE;
+
+	/**
+	 * The operation id for the '<em>Can Precede</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int PARALLEL_SPLIT___CAN_PRECEDE = DIVERGENCE___CAN_PRECEDE;
+
+	/**
+	 * The operation id for the '<em>Can Succeed</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int PARALLEL_SPLIT___CAN_SUCCEED = DIVERGENCE___CAN_SUCCEED;
 
 	/**
 	 * The number of operations of the '<em>Parallel Split</em>' class.
@@ -822,6 +1074,42 @@ public interface SpecPackage extends EPackage {
 	int EXTERNAL_TASK___CAN_SUCCEED__NODE = TASK___CAN_SUCCEED__NODE;
 
 	/**
+	 * The operation id for the '<em>Precedes</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int EXTERNAL_TASK___PRECEDES__NODE = TASK___PRECEDES__NODE;
+
+	/**
+	 * The operation id for the '<em>Succeeds</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int EXTERNAL_TASK___SUCCEEDS__NODE = TASK___SUCCEEDS__NODE;
+
+	/**
+	 * The operation id for the '<em>Can Precede</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int EXTERNAL_TASK___CAN_PRECEDE = TASK___CAN_PRECEDE;
+
+	/**
+	 * The operation id for the '<em>Can Succeed</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int EXTERNAL_TASK___CAN_SUCCEED = TASK___CAN_SUCCEED;
+
+	/**
 	 * The number of operations of the '<em>External Task</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -931,6 +1219,42 @@ public interface SpecPackage extends EPackage {
 	int LIBRARY_TASK___CAN_SUCCEED__NODE = TASK___CAN_SUCCEED__NODE;
 
 	/**
+	 * The operation id for the '<em>Precedes</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int LIBRARY_TASK___PRECEDES__NODE = TASK___PRECEDES__NODE;
+
+	/**
+	 * The operation id for the '<em>Succeeds</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int LIBRARY_TASK___SUCCEEDS__NODE = TASK___SUCCEEDS__NODE;
+
+	/**
+	 * The operation id for the '<em>Can Precede</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int LIBRARY_TASK___CAN_PRECEDE = TASK___CAN_PRECEDE;
+
+	/**
+	 * The operation id for the '<em>Can Succeed</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int LIBRARY_TASK___CAN_SUCCEED = TASK___CAN_SUCCEED;
+
+	/**
 	 * The number of operations of the '<em>Library Task</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -993,6 +1317,42 @@ public interface SpecPackage extends EPackage {
 	 * @ordered
 	 */
 	int CONVERGENCE___CAN_SUCCEED__NODE = NODE___CAN_SUCCEED__NODE;
+
+	/**
+	 * The operation id for the '<em>Precedes</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int CONVERGENCE___PRECEDES__NODE = NODE___PRECEDES__NODE;
+
+	/**
+	 * The operation id for the '<em>Succeeds</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int CONVERGENCE___SUCCEEDS__NODE = NODE___SUCCEEDS__NODE;
+
+	/**
+	 * The operation id for the '<em>Can Precede</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int CONVERGENCE___CAN_PRECEDE = NODE___CAN_PRECEDE;
+
+	/**
+	 * The operation id for the '<em>Can Succeed</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int CONVERGENCE___CAN_SUCCEED = NODE___CAN_SUCCEED;
 
 	/**
 	 * The number of operations of the '<em>Convergence</em>' class.
@@ -1059,6 +1419,42 @@ public interface SpecPackage extends EPackage {
 	int SYNCHRONIZATION___CAN_SUCCEED__NODE = CONVERGENCE___CAN_SUCCEED__NODE;
 
 	/**
+	 * The operation id for the '<em>Precedes</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int SYNCHRONIZATION___PRECEDES__NODE = CONVERGENCE___PRECEDES__NODE;
+
+	/**
+	 * The operation id for the '<em>Succeeds</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int SYNCHRONIZATION___SUCCEEDS__NODE = CONVERGENCE___SUCCEEDS__NODE;
+
+	/**
+	 * The operation id for the '<em>Can Precede</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int SYNCHRONIZATION___CAN_PRECEDE = CONVERGENCE___CAN_PRECEDE;
+
+	/**
+	 * The operation id for the '<em>Can Succeed</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int SYNCHRONIZATION___CAN_SUCCEED = CONVERGENCE___CAN_SUCCEED;
+
+	/**
 	 * The number of operations of the '<em>Synchronization</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -1121,6 +1517,42 @@ public interface SpecPackage extends EPackage {
 	 * @ordered
 	 */
 	int CONDITIONAL_DIVERGENCE___CAN_SUCCEED__NODE = STARTING_NODE___CAN_SUCCEED__NODE;
+
+	/**
+	 * The operation id for the '<em>Precedes</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int CONDITIONAL_DIVERGENCE___PRECEDES__NODE = STARTING_NODE___PRECEDES__NODE;
+
+	/**
+	 * The operation id for the '<em>Succeeds</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int CONDITIONAL_DIVERGENCE___SUCCEEDS__NODE = STARTING_NODE___SUCCEEDS__NODE;
+
+	/**
+	 * The operation id for the '<em>Can Precede</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int CONDITIONAL_DIVERGENCE___CAN_PRECEDE = STARTING_NODE___CAN_PRECEDE;
+
+	/**
+	 * The operation id for the '<em>Can Succeed</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int CONDITIONAL_DIVERGENCE___CAN_SUCCEED = STARTING_NODE___CAN_SUCCEED;
 
 	/**
 	 * The number of operations of the '<em>Conditional Divergence</em>' class.
@@ -1187,6 +1619,42 @@ public interface SpecPackage extends EPackage {
 	int MULTI_CHOICE___CAN_SUCCEED__NODE = CONDITIONAL_DIVERGENCE___CAN_SUCCEED__NODE;
 
 	/**
+	 * The operation id for the '<em>Precedes</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int MULTI_CHOICE___PRECEDES__NODE = CONDITIONAL_DIVERGENCE___PRECEDES__NODE;
+
+	/**
+	 * The operation id for the '<em>Succeeds</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int MULTI_CHOICE___SUCCEEDS__NODE = CONDITIONAL_DIVERGENCE___SUCCEEDS__NODE;
+
+	/**
+	 * The operation id for the '<em>Can Precede</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int MULTI_CHOICE___CAN_PRECEDE = CONDITIONAL_DIVERGENCE___CAN_PRECEDE;
+
+	/**
+	 * The operation id for the '<em>Can Succeed</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int MULTI_CHOICE___CAN_SUCCEED = CONDITIONAL_DIVERGENCE___CAN_SUCCEED;
+
+	/**
 	 * The number of operations of the '<em>Multi Choice</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -1249,6 +1717,42 @@ public interface SpecPackage extends EPackage {
 	 * @ordered
 	 */
 	int SIMPLE_MERGE___CAN_SUCCEED__NODE = CONVERGENCE___CAN_SUCCEED__NODE;
+
+	/**
+	 * The operation id for the '<em>Precedes</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int SIMPLE_MERGE___PRECEDES__NODE = CONVERGENCE___PRECEDES__NODE;
+
+	/**
+	 * The operation id for the '<em>Succeeds</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int SIMPLE_MERGE___SUCCEEDS__NODE = CONVERGENCE___SUCCEEDS__NODE;
+
+	/**
+	 * The operation id for the '<em>Can Precede</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int SIMPLE_MERGE___CAN_PRECEDE = CONVERGENCE___CAN_PRECEDE;
+
+	/**
+	 * The operation id for the '<em>Can Succeed</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int SIMPLE_MERGE___CAN_SUCCEED = CONVERGENCE___CAN_SUCCEED;
 
 	/**
 	 * The number of operations of the '<em>Simple Merge</em>' class.
@@ -1551,6 +2055,42 @@ public interface SpecPackage extends EPackage {
 	 * @ordered
 	 */
 	int CONDITION___CAN_SUCCEED__NODE = TASK___CAN_SUCCEED__NODE;
+
+	/**
+	 * The operation id for the '<em>Precedes</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int CONDITION___PRECEDES__NODE = TASK___PRECEDES__NODE;
+
+	/**
+	 * The operation id for the '<em>Succeeds</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int CONDITION___SUCCEEDS__NODE = TASK___SUCCEEDS__NODE;
+
+	/**
+	 * The operation id for the '<em>Can Precede</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int CONDITION___CAN_PRECEDE = TASK___CAN_PRECEDE;
+
+	/**
+	 * The operation id for the '<em>Can Succeed</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int CONDITION___CAN_SUCCEED = TASK___CAN_SUCCEED;
 
 	/**
 	 * The number of operations of the '<em>Condition</em>' class.
@@ -2018,6 +2558,46 @@ public interface SpecPackage extends EPackage {
 	EOperation getNode__CanSucceed__Node();
 
 	/**
+	 * Returns the meta object for the '{@link fr.kazejiyu.ekumi.model.spec.Node#precedes(fr.kazejiyu.ekumi.model.spec.Node) <em>Precedes</em>}' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the '<em>Precedes</em>' operation.
+	 * @see fr.kazejiyu.ekumi.model.spec.Node#precedes(fr.kazejiyu.ekumi.model.spec.Node)
+	 * @generated
+	 */
+	EOperation getNode__Precedes__Node();
+
+	/**
+	 * Returns the meta object for the '{@link fr.kazejiyu.ekumi.model.spec.Node#succeeds(fr.kazejiyu.ekumi.model.spec.Node) <em>Succeeds</em>}' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the '<em>Succeeds</em>' operation.
+	 * @see fr.kazejiyu.ekumi.model.spec.Node#succeeds(fr.kazejiyu.ekumi.model.spec.Node)
+	 * @generated
+	 */
+	EOperation getNode__Succeeds__Node();
+
+	/**
+	 * Returns the meta object for the '{@link fr.kazejiyu.ekumi.model.spec.Node#canPrecede() <em>Can Precede</em>}' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the '<em>Can Precede</em>' operation.
+	 * @see fr.kazejiyu.ekumi.model.spec.Node#canPrecede()
+	 * @generated
+	 */
+	EOperation getNode__CanPrecede();
+
+	/**
+	 * Returns the meta object for the '{@link fr.kazejiyu.ekumi.model.spec.Node#canSucceed() <em>Can Succeed</em>}' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the '<em>Can Succeed</em>' operation.
+	 * @see fr.kazejiyu.ekumi.model.spec.Node#canSucceed()
+	 * @generated
+	 */
+	EOperation getNode__CanSucceed();
+
+	/**
 	 * Returns the meta object for class '{@link fr.kazejiyu.ekumi.model.spec.ConditionalDivergence <em>Conditional Divergence</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -2475,6 +3055,38 @@ public interface SpecPackage extends EPackage {
 		 * @generated
 		 */
 		EOperation NODE___CAN_SUCCEED__NODE = eINSTANCE.getNode__CanSucceed__Node();
+
+		/**
+		 * The meta object literal for the '<em><b>Precedes</b></em>' operation.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EOperation NODE___PRECEDES__NODE = eINSTANCE.getNode__Precedes__Node();
+
+		/**
+		 * The meta object literal for the '<em><b>Succeeds</b></em>' operation.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EOperation NODE___SUCCEEDS__NODE = eINSTANCE.getNode__Succeeds__Node();
+
+		/**
+		 * The meta object literal for the '<em><b>Can Precede</b></em>' operation.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EOperation NODE___CAN_PRECEDE = eINSTANCE.getNode__CanPrecede();
+
+		/**
+		 * The meta object literal for the '<em><b>Can Succeed</b></em>' operation.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EOperation NODE___CAN_SUCCEED = eINSTANCE.getNode__CanSucceed();
 
 		/**
 		 * The meta object literal for the '{@link fr.kazejiyu.ekumi.model.spec.impl.ConditionalDivergenceImpl <em>Conditional Divergence</em>}' class.

--- a/bundles/fr.kazejiyu.ekumi.model/src-gen/fr/kazejiyu/ekumi/model/spec/impl/NodeImpl.java
+++ b/bundles/fr.kazejiyu.ekumi.model/src-gen/fr/kazejiyu/ekumi/model/spec/impl/NodeImpl.java
@@ -126,6 +126,48 @@ public abstract class NodeImpl extends MinimalEObjectImpl.Container implements N
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * @generated NOT
+	 */
+	public boolean precedes(Node successor) {
+		return getSuccessors().contains(successor);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public boolean succeeds(Node predecessor) {
+		// TODO: implement this method
+		// Ensure that you remove @generated or mark it @generated NOT
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public boolean canPrecede() {
+		// TODO: implement this method
+		// Ensure that you remove @generated or mark it @generated NOT
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public boolean canSucceed() {
+		// TODO: implement this method
+		// Ensure that you remove @generated or mark it @generated NOT
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -239,6 +281,14 @@ public abstract class NodeImpl extends MinimalEObjectImpl.Container implements N
 			return canPrecede((Node) arguments.get(0));
 		case SpecPackage.NODE___CAN_SUCCEED__NODE:
 			return canSucceed((Node) arguments.get(0));
+		case SpecPackage.NODE___PRECEDES__NODE:
+			return precedes((Node) arguments.get(0));
+		case SpecPackage.NODE___SUCCEEDS__NODE:
+			return succeeds((Node) arguments.get(0));
+		case SpecPackage.NODE___CAN_PRECEDE:
+			return canPrecede();
+		case SpecPackage.NODE___CAN_SUCCEED:
+			return canSucceed();
 		}
 		return super.eInvoke(operationID, arguments);
 	}

--- a/bundles/fr.kazejiyu.ekumi.model/src-gen/fr/kazejiyu/ekumi/model/spec/impl/SpecPackageImpl.java
+++ b/bundles/fr.kazejiyu.ekumi.model/src-gen/fr/kazejiyu/ekumi/model/spec/impl/SpecPackageImpl.java
@@ -653,6 +653,42 @@ public class SpecPackageImpl extends EPackageImpl implements SpecPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	public EOperation getNode__Precedes__Node() {
+		return nodeEClass.getEOperations().get(2);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EOperation getNode__Succeeds__Node() {
+		return nodeEClass.getEOperations().get(3);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EOperation getNode__CanPrecede() {
+		return nodeEClass.getEOperations().get(4);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EOperation getNode__CanSucceed() {
+		return nodeEClass.getEOperations().get(5);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
 	public EClass getConditionalDivergence() {
 		return conditionalDivergenceEClass;
 	}
@@ -788,6 +824,10 @@ public class SpecPackageImpl extends EPackageImpl implements SpecPackage {
 		createEReference(nodeEClass, NODE__PREDECESSORS);
 		createEOperation(nodeEClass, NODE___CAN_PRECEDE__NODE);
 		createEOperation(nodeEClass, NODE___CAN_SUCCEED__NODE);
+		createEOperation(nodeEClass, NODE___PRECEDES__NODE);
+		createEOperation(nodeEClass, NODE___SUCCEEDS__NODE);
+		createEOperation(nodeEClass, NODE___CAN_PRECEDE);
+		createEOperation(nodeEClass, NODE___CAN_SUCCEED);
 
 		conditionalDivergenceEClass = createEClass(CONDITIONAL_DIVERGENCE);
 
@@ -969,6 +1009,20 @@ public class SpecPackageImpl extends EPackageImpl implements SpecPackage {
 		op = initEOperation(getNode__CanSucceed__Node(), theXMLTypePackage.getBoolean(), "canSucceed", 0, 1, IS_UNIQUE,
 				IS_ORDERED);
 		addEParameter(op, this.getNode(), "node", 0, 1, IS_UNIQUE, IS_ORDERED);
+
+		op = initEOperation(getNode__Precedes__Node(), theXMLTypePackage.getBoolean(), "precedes", 0, 1, IS_UNIQUE,
+				IS_ORDERED);
+		addEParameter(op, this.getNode(), "successor", 0, 1, IS_UNIQUE, IS_ORDERED);
+
+		op = initEOperation(getNode__Succeeds__Node(), theXMLTypePackage.getBoolean(), "succeeds", 0, 1, IS_UNIQUE,
+				IS_ORDERED);
+		addEParameter(op, this.getNode(), "predecessor", 0, 1, IS_UNIQUE, IS_ORDERED);
+
+		initEOperation(getNode__CanPrecede(), theXMLTypePackage.getBoolean(), "canPrecede", 0, 1, IS_UNIQUE,
+				IS_ORDERED);
+
+		initEOperation(getNode__CanSucceed(), theXMLTypePackage.getBoolean(), "canSucceed", 0, 1, IS_UNIQUE,
+				IS_ORDERED);
 
 		initEClass(conditionalDivergenceEClass, ConditionalDivergence.class, "ConditionalDivergence", IS_ABSTRACT,
 				!IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);

--- a/bundles/fr.kazejiyu.ekumi.workflow.editor.design/description/workflow-editor.odesign
+++ b/bundles/fr.kazejiyu.ekumi.workflow.editor.design/description/workflow-editor.odesign
@@ -125,7 +125,7 @@
           </ownedTools>
         </toolSections>
         <toolSections name="Relationships">
-          <ownedTools xsi:type="tool:EdgeCreationDescription" name="Relationship" precondition="aql: preSource.canPrecede(preTarget) and preTarget.canSucceed(preSource)" edgeMappings="//@ownedViewpoints[name='EKumi%20Workflow']/@ownedRepresentations[name='Workflow%20Diagram']/@defaultLayer/@edgeMappings[name='Node%20successor']">
+          <ownedTools xsi:type="tool:EdgeCreationDescription" name="Precede" precondition="aql: preSource.canPrecede(preTarget) and preTarget.canSucceed(preSource)" edgeMappings="//@ownedViewpoints[name='EKumi%20Workflow']/@ownedRepresentations[name='Workflow%20Diagram']/@defaultLayer/@edgeMappings[name='Node%20successor']" connectionStartPrecondition="aql: preSource.canPrecede()">
             <sourceVariable name="source"/>
             <targetVariable name="target"/>
             <sourceViewVariable name="sourceView"/>

--- a/tests/fr.kazejiyu.ekumi.core.test/src/fr/kazejiyu/ekumi/core/spec/impl/BasicExternalTaskTest.java
+++ b/tests/fr.kazejiyu.ekumi.core.test/src/fr/kazejiyu/ekumi/core/spec/impl/BasicExternalTaskTest.java
@@ -1,0 +1,63 @@
+package fr.kazejiyu.ekumi.core.spec.impl;
+
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import fr.kazejiyu.ekumi.core.spec.impl.fake.FakePredecessor;
+import fr.kazejiyu.ekumi.core.spec.impl.fake.FakeSuccessor;
+import fr.kazejiyu.ekumi.model.spec.ExternalTask;
+import fr.kazejiyu.ekumi.model.spec.Node;
+
+@DisplayName("A Basic ExternalTask")
+public class BasicExternalTaskTest implements WithAssertions {
+	
+	ExternalTask task;
+	
+	Node successor;
+	Node predecessor;
+	
+	@BeforeEach
+	void createTask() {
+		task = new BasicExternalTask();
+		
+		successor = new FakeSuccessor();
+		predecessor = new FakePredecessor();
+	}
+	
+	@Test @DisplayName("can have a successor")
+	void can_have_a_successor() {
+		assertThat(task.canPrecede(successor)).isTrue();
+	}
+	
+	@Test @DisplayName("can have at most one successor") 
+	void can_have_at_most_one_successor() {
+		task.getSuccessors().add(successor);
+		
+		assertThat(task.canPrecede(new FakeSuccessor())).isFalse();
+	}
+	
+	@Test @DisplayName("cannot be its own successor")
+	void cannot_be_its_own_successor() {
+		assertThat(task.canPrecede(task)).isFalse();
+	}
+	
+	@Test @DisplayName("can have a predecessor")
+	void can_have_a_predecessor() {
+		assertThat(task.canSucceed(predecessor)).isTrue();
+	}
+	
+	@Test @DisplayName("can have at most one predecessor")
+	void can_have_at_most_one_predecessor() {
+		task.getPredecessors().add(predecessor);
+		
+		assertThat(task.canSucceed(new FakePredecessor())).isFalse();
+	}
+	
+	@Test @DisplayName("cannot be its own predecessor")
+	void cannot_be_its_own_predecessor() {
+		assertThat(task.canSucceed(task)).isFalse();
+	}
+
+}

--- a/tests/fr.kazejiyu.ekumi.core.test/src/fr/kazejiyu/ekumi/core/spec/impl/BasicMultiChoiceTest.java
+++ b/tests/fr.kazejiyu.ekumi.core.test/src/fr/kazejiyu/ekumi/core/spec/impl/BasicMultiChoiceTest.java
@@ -1,0 +1,91 @@
+package fr.kazejiyu.ekumi.core.spec.impl;
+
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import fr.kazejiyu.ekumi.core.spec.impl.fake.FakePredecessor;
+import fr.kazejiyu.ekumi.core.spec.impl.fake.FakeSuccessor;
+import fr.kazejiyu.ekumi.model.spec.MultiChoice;
+import fr.kazejiyu.ekumi.model.spec.Node;
+
+@DisplayName("A Basic MultiChoice")
+public class BasicMultiChoiceTest implements WithAssertions {
+	
+	/** The object to test */
+	MultiChoice choice;
+	
+	Node successor;
+	Node predecessor;
+	
+	@BeforeEach
+	void createMultiChoice() {
+		choice = new BasicMultiChoice();
+		
+		successor = new FakeSuccessor();
+		predecessor = new FakePredecessor();
+	}
+	
+	@Test @DisplayName("can precede a node")
+	void can_precede_a_node() {
+		assertThat(choice.canPrecede()).isTrue();
+	}
+	
+	@Test @DisplayName("can have a successor")
+	void can_have_a_successor() {
+		assertThat(choice.canPrecede()).isTrue();
+	}
+	
+	@Test @DisplayName("can have a given successor")
+	void can_have_a_given_successor() {
+		assertThat(choice.canPrecede(successor)).isTrue();
+	}
+	
+	@Test @DisplayName("can have many successors") 
+	void can_have_many_successors() {
+		choice.getSuccessors().add(successor);
+		
+		SoftAssertions softly = new SoftAssertions();
+		
+		for (int i = 0 ; i < 100 ; ++i)
+			softly.assertThat(choice.canPrecede(new FakeSuccessor())).isTrue();
+		
+		softly.assertAll();
+	}
+	
+	@Test @DisplayName("can precede the same task multiple times")
+	void can_precede_the_same_task_multiple_times() {
+		SoftAssertions softly = new SoftAssertions();
+		
+		for (int i = 0 ; i < 10 ; ++i) {
+			choice.getSuccessors().add(successor);
+			softly.assertThat(choice.canPrecede(successor)).isTrue();
+		}
+		softly.assertAll();
+	}
+	
+	@Test @DisplayName("cannot be its own successor")
+	void cannot_be_its_own_successor() {
+		assertThat(choice.canPrecede(choice)).isFalse();
+	}
+	
+	@Test @DisplayName("can have a predecessor")
+	void can_have_a_predecessor() {
+		assertThat(choice.canSucceed(predecessor)).isTrue();
+	}
+	
+	@Test @DisplayName("can have at most one predecessor")
+	void can_have_at_most_one_predecessor() {
+		choice.getPredecessors().add(predecessor);
+		
+		assertThat(choice.canSucceed(new FakePredecessor())).isFalse();
+	}
+	
+	@Test @DisplayName("cannot be its own predecessor")
+	void cannot_be_its_own_predecessor() {
+		assertThat(choice.canSucceed(choice)).isFalse();
+	}
+
+}

--- a/tests/fr.kazejiyu.ekumi.core.test/src/fr/kazejiyu/ekumi/core/spec/impl/BasicParallelSplitTest.java
+++ b/tests/fr.kazejiyu.ekumi.core.test/src/fr/kazejiyu/ekumi/core/spec/impl/BasicParallelSplitTest.java
@@ -1,0 +1,82 @@
+package fr.kazejiyu.ekumi.core.spec.impl;
+
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import fr.kazejiyu.ekumi.core.spec.impl.fake.FakePredecessor;
+import fr.kazejiyu.ekumi.core.spec.impl.fake.FakeSuccessor;
+import fr.kazejiyu.ekumi.model.spec.Node;
+import fr.kazejiyu.ekumi.model.spec.ParallelSplit;
+
+@DisplayName("A Basic ParallelSplit")
+public class BasicParallelSplitTest implements WithAssertions {
+	
+	/** The object to test */
+	ParallelSplit split;
+	
+	Node successor;
+	Node predecessor;
+	
+	@BeforeEach
+	void createParallelSplit() {
+		split = new BasicParallelSplit();
+		
+		successor = new FakeSuccessor();
+		predecessor = new FakePredecessor();
+	}
+	
+	@Test @DisplayName("can have a successor")
+	void can_have_a_successor() {
+		assertThat(split.canPrecede()).isTrue();
+	}
+	
+	@Test @DisplayName("can have a given successor")
+	void can_have_a_given_successor() {
+		assertThat(split.canPrecede(successor)).isTrue();
+	}
+	
+	@Test @DisplayName("can have many successors") 
+	void can_have_many_successors() {
+		split.getSuccessors().add(successor);
+		
+		SoftAssertions softly = new SoftAssertions();
+		
+		for (int i = 0 ; i < 100 ; ++i)
+			softly.assertThat(split.canPrecede(new FakeSuccessor())).isTrue();
+		
+		softly.assertAll();
+	}
+	
+	@Test @DisplayName("cannot precede the same task multiple times")
+	void cannot_precede_the_same_task_multiple_times() {
+		split.getSuccessors().add(successor);
+
+		assertThat(split.canPrecede(successor)).isFalse();
+	}
+	
+	@Test @DisplayName("cannot be its own successor")
+	void cannot_be_its_own_successor() {
+		assertThat(split.canPrecede(split)).isFalse();
+	}
+	
+	@Test @DisplayName("can have a predecessor")
+	void can_have_a_predecessor() {
+		assertThat(split.canSucceed(predecessor)).isTrue();
+	}
+	
+	@Test @DisplayName("can have at most one predecessor")
+	void can_have_at_most_one_predecessor() {
+		split.getPredecessors().add(predecessor);
+		
+		assertThat(split.canSucceed(new FakePredecessor())).isFalse();
+	}
+	
+	@Test @DisplayName("cannot be its own predecessor")
+	void cannot_be_its_own_predecessor() {
+		assertThat(split.canSucceed(split)).isFalse();
+	}
+
+}

--- a/tests/fr.kazejiyu.ekumi.core.test/src/fr/kazejiyu/ekumi/core/spec/impl/BasicSimpleMergeTest.java
+++ b/tests/fr.kazejiyu.ekumi.core.test/src/fr/kazejiyu/ekumi/core/spec/impl/BasicSimpleMergeTest.java
@@ -1,0 +1,91 @@
+package fr.kazejiyu.ekumi.core.spec.impl;
+
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import fr.kazejiyu.ekumi.core.spec.impl.fake.FakePredecessor;
+import fr.kazejiyu.ekumi.core.spec.impl.fake.FakeSuccessor;
+import fr.kazejiyu.ekumi.model.spec.Node;
+import fr.kazejiyu.ekumi.model.spec.SimpleMerge;
+
+@DisplayName("A Basic SimpleMerge")
+public class BasicSimpleMergeTest implements WithAssertions {
+	
+	/** The object to test */
+	SimpleMerge merge;
+	
+	Node successor;
+	Node predecessor;
+	
+	@BeforeEach
+	void createSimpleMerge() {
+		merge = new BasicSimpleMerge();
+		
+		successor = new FakeSuccessor();
+		predecessor = new FakePredecessor();
+	}
+	
+	@Test @DisplayName("can have a successor")
+	void can_have_a_successor() {
+		assertThat(merge.canPrecede(successor)).isTrue();
+	}
+	
+	@Test @DisplayName("can have many successors") 
+	void can_have_many_successors() {
+		merge.getSuccessors().add(successor);
+		
+		assertThat(merge.canPrecede(new FakeSuccessor())).isFalse();
+	}
+	
+	@Test @DisplayName("can have a predecessor")
+	void can_have_a_predecessor() {
+		assertThat(merge.canPrecede()).isTrue();
+	}
+	
+	@Test @DisplayName("cannot be its own predecessor")
+	void cannot_be_its_own_predecessor() {
+		assertThat(merge.canPrecede(merge)).isFalse();
+	}
+	
+	@Test @DisplayName("can succeed a node")
+	void can_succeed_a_node() {
+		assertThat(merge.canSucceed()).isTrue();
+	}
+	
+	@Test @DisplayName("can have a given predecessor")
+	void can_have_a_given_predecessor() {
+		assertThat(merge.canSucceed(predecessor)).isTrue();
+	}
+	
+	@Test @DisplayName("can have many predecessors")
+	void can_have_many_predecessors() {
+		merge.getPredecessors().add(predecessor);
+		
+		SoftAssertions softly = new SoftAssertions();
+		
+		for (int i = 0 ; i < 100 ; ++i)
+			softly.assertThat(merge.canSucceed(new FakePredecessor())).isTrue();
+		
+		softly.assertAll();
+	}
+	
+	@Test @DisplayName("cannot succeed the same task multiple times")
+	void cannot_succeed_the_same_task_multiple_times() {
+		SoftAssertions softly = new SoftAssertions();
+		
+		for (int i = 0 ; i < 10 ; ++i) {
+			merge.getPredecessors().add(predecessor);
+			softly.assertThat(merge.canSucceed(predecessor)).isFalse();
+		}
+		softly.assertAll();
+	}
+	
+	@Test @DisplayName("cannot be its own successor")
+	void cannot_be_its_own_successor() {
+		assertThat(merge.canSucceed(merge)).isFalse();
+	}
+
+}

--- a/tests/fr.kazejiyu.ekumi.core.test/src/fr/kazejiyu/ekumi/core/spec/impl/BasicSpecFactoryTest.java
+++ b/tests/fr.kazejiyu.ekumi.core.test/src/fr/kazejiyu/ekumi/core/spec/impl/BasicSpecFactoryTest.java
@@ -1,0 +1,54 @@
+package fr.kazejiyu.ekumi.core.spec.impl;
+
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import fr.kazejiyu.ekumi.model.spec.Node;
+
+@DisplayName("A Basic SpecFactory")
+public class BasicSpecFactoryTest implements WithAssertions {
+	
+	/** Object to test */
+	BasicSpecFactory factory;
+	
+	Node successor;
+	Node predecessor;
+	
+	@BeforeEach
+	void createTask() {
+		factory = new BasicSpecFactory();
+	}
+	
+	@Test @DisplayName("can create a Start")
+	void can_create_a_start() {
+		assertThat(factory.createStart()).isNotNull();
+	}
+	
+	@Test @DisplayName("can create an ExternalTask")
+	void can_create_an_external_task() {
+		assertThat(factory.createExternalTask()).isNotNull();
+	}
+	
+	@Test @DisplayName("can create a ParallelSplit")
+	void can_create_an_parallel_split() {
+		assertThat(factory.createParallelSplit()).isNotNull();
+	}
+	
+	@Test @DisplayName("can create a Synchronization")
+	void can_create_a_synchronization() {
+		assertThat(factory.createSynchronization()).isNotNull();
+	}
+	
+	@Test @DisplayName("can create a MultiChoice")
+	void can_create_a_multi_choice() {
+		assertThat(factory.createMultiChoice()).isNotNull();
+	}
+	
+	@Test @DisplayName("can create a SimpleMerge")
+	void can_create_a_simple_merge() {
+		assertThat(factory.createSimpleMerge()).isNotNull();
+	}
+	
+}

--- a/tests/fr.kazejiyu.ekumi.core.test/src/fr/kazejiyu/ekumi/core/spec/impl/BasicStartTest.java
+++ b/tests/fr.kazejiyu.ekumi.core.test/src/fr/kazejiyu/ekumi/core/spec/impl/BasicStartTest.java
@@ -1,0 +1,62 @@
+package fr.kazejiyu.ekumi.core.spec.impl;
+
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import fr.kazejiyu.ekumi.core.spec.impl.fake.FakePredecessor;
+import fr.kazejiyu.ekumi.core.spec.impl.fake.FakeSuccessor;
+import fr.kazejiyu.ekumi.model.spec.Node;
+import fr.kazejiyu.ekumi.model.spec.Start;
+
+@DisplayName("A Basic Start")
+public class BasicStartTest implements WithAssertions {
+	
+	/** Object to test */
+	Start start;
+	
+	Node successor;
+	Node predecessor;
+	
+	@BeforeEach
+	void createTask() {
+		start = new BasicStart();
+		
+		successor = new FakeSuccessor();
+		predecessor = new FakePredecessor();
+	}
+	
+	@Test @DisplayName("can have a successor")
+	void can_have_a_successor() {
+		assertThat(start.canPrecede(successor)).isTrue();
+	}
+	
+	@Test @DisplayName("can have only one successor")
+	void can_have_only_one_successor() {
+		start.getSuccessors().add(successor);
+		
+		assertThat(start.canPrecede(new FakeSuccessor())).isFalse();
+	}
+	
+	@Test @DisplayName("cannot be its own successor")
+	void cannot_be_its_own_successor() {
+		assertThat(start.canPrecede(start)).isFalse();
+	}
+	
+	@Test @DisplayName("cannot succeed a node")
+	void cannot_succeed_a_node() {
+		assertThat(start.canSucceed()).isFalse();
+	}
+	
+	@Test @DisplayName("cannot have any predecessor") 
+	void cannot_have_any_predecessor() {
+		assertThat(start.canSucceed(predecessor)).isFalse();
+	}
+	
+	@Test @DisplayName("cannot be its own predecessor")
+	void cannot_be_its_own_predecessor() {
+		assertThat(start.canSucceed(start)).isFalse();
+	}
+	
+}

--- a/tests/fr.kazejiyu.ekumi.core.test/src/fr/kazejiyu/ekumi/core/spec/impl/BasicSynchronizationTest.java
+++ b/tests/fr.kazejiyu.ekumi.core.test/src/fr/kazejiyu/ekumi/core/spec/impl/BasicSynchronizationTest.java
@@ -1,0 +1,92 @@
+package fr.kazejiyu.ekumi.core.spec.impl;
+
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import fr.kazejiyu.ekumi.core.spec.impl.fake.FakePredecessor;
+import fr.kazejiyu.ekumi.core.spec.impl.fake.FakeSuccessor;
+import fr.kazejiyu.ekumi.model.spec.Node;
+import fr.kazejiyu.ekumi.model.spec.Synchronization;
+
+@DisplayName("A Basic Synchronization")
+public class BasicSynchronizationTest implements WithAssertions {
+	
+	/** The object to test */
+	Synchronization sync;
+	
+	Node successor;
+	Node predecessor;
+	
+	@BeforeEach
+	void createSimpleMerge() {
+		sync = new BasicSynchronization();
+		
+		successor = new FakeSuccessor();
+		predecessor = new FakePredecessor();
+	}
+	
+	@Test @DisplayName("can have a successor")
+	void can_have_a_successor() {
+		assertThat(sync.canPrecede(successor)).isTrue();
+	}
+	
+	@Test @DisplayName("can have at most one successor") 
+	void can_have_many_successors() {
+		sync.getSuccessors().add(successor);
+		
+		assertThat(sync.canPrecede(new FakeSuccessor())).isFalse();
+	}
+	
+	@Test @DisplayName("can have a predecessor")
+	void can_have_a_predecessor() {
+		assertThat(sync.canPrecede()).isTrue();
+	}
+	
+	@Test @DisplayName("cannot be its own predecessor")
+	void cannot_be_its_own_predecessor() {
+		assertThat(sync.canPrecede(sync)).isFalse();
+	}
+	
+	@Test @DisplayName("can succeed a node")
+	void can_succeed_a_node() {
+		assertThat(sync.canSucceed()).isTrue();
+	}
+	
+	@Test @DisplayName("can have a given predecessor")
+	void can_have_a_given_predecessor() {
+		assertThat(sync.canSucceed(predecessor)).isTrue();
+	}
+	
+	@Test @DisplayName("can have many predecessors")
+	void can_have_many_one_predecessors() {
+		sync.getPredecessors().add(predecessor);
+		
+		SoftAssertions softly = new SoftAssertions();
+		
+		for (int i = 0 ; i < 100 ; ++i)
+			softly.assertThat(sync.canSucceed(new FakePredecessor())).isTrue();
+		
+		softly.assertAll();
+	}
+	
+	@Test @DisplayName("cannot succeed the same task multiple times")
+	void cannot_succeed_the_same_task_multiple_times() {
+		sync.getPredecessors().add(predecessor);
+
+		SoftAssertions softly = new SoftAssertions();
+		
+		for (int i = 0 ; i < 10 ; ++i) {
+			softly.assertThat(sync.canSucceed(predecessor)).isFalse();
+		}
+		softly.assertAll();
+	}
+	
+	@Test @DisplayName("cannot be its own successor")
+	void cannot_be_its_own_successor() {
+		assertThat(sync.canSucceed(sync)).isFalse();
+	}
+
+}

--- a/tests/fr.kazejiyu.ekumi.core.test/src/fr/kazejiyu/ekumi/core/spec/impl/fake/FakePredecessor.java
+++ b/tests/fr.kazejiyu.ekumi.core.test/src/fr/kazejiyu/ekumi/core/spec/impl/fake/FakePredecessor.java
@@ -1,0 +1,13 @@
+package fr.kazejiyu.ekumi.core.spec.impl.fake;
+
+import fr.kazejiyu.ekumi.model.spec.Node;
+import fr.kazejiyu.ekumi.model.spec.impl.NodeImpl;
+
+public class FakePredecessor extends NodeImpl {
+	
+	@Override
+	public boolean canPrecede(Node node) {
+		return true;
+	}
+
+}

--- a/tests/fr.kazejiyu.ekumi.core.test/src/fr/kazejiyu/ekumi/core/spec/impl/fake/FakeSuccessor.java
+++ b/tests/fr.kazejiyu.ekumi.core.test/src/fr/kazejiyu/ekumi/core/spec/impl/fake/FakeSuccessor.java
@@ -1,0 +1,13 @@
+package fr.kazejiyu.ekumi.core.spec.impl.fake;
+
+import fr.kazejiyu.ekumi.model.spec.Node;
+import fr.kazejiyu.ekumi.model.spec.impl.NodeImpl;
+
+public class FakeSuccessor extends NodeImpl {
+	
+	@Override
+	public boolean canSucceed(Node node) {
+		return true;
+	}
+
+}


### PR DESCRIPTION
Example of constraints:
 - a start node cannot have a predecessor
 - a task cannot have multiple successors
 - a split can have multiple successors