### PR TITLE
Provide a new project_customization extension point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
+- Customization of new Workflow projects ([#34](https://github.com/KazeJiyu/ekumi/pull/34))
 - Simple workflow diagram editor ([#26](https://github.com/KazeJiyu/ekumi/pull/26))
 - Launch configurations for Activity ([#20](https://github.com/KazeJiyu/ekumi/pull/20))
 - Automatic update of the History View ([#22](https://github.com/KazeJiyu/ekumi/pull/22))

--- a/bundles/fr.kazejiyu.ekumi.ide.ui/src/fr/kazejiyu/ekumi/ide/ui/Activator.java
+++ b/bundles/fr.kazejiyu.ekumi.ide.ui/src/fr/kazejiyu/ekumi/ide/ui/Activator.java
@@ -9,6 +9,8 @@
  ******************************************************************************/
 package fr.kazejiyu.ekumi.ide.ui;
 
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 
@@ -18,17 +20,11 @@ import org.osgi.framework.BundleContext;
 public class Activator extends AbstractUIPlugin {
 
 	// The plug-in ID
-	public static final String PLUGIN_ID = "fr.kazejiyu.ekumi.ide.ui"; //$NON-NLS-1$
+	public static final String ID = "fr.kazejiyu.ekumi.ide.ui"; //$NON-NLS-1$
 
 	// The shared instance
 	private static Activator plugin;
 	
-	/**
-	 * The constructor
-	 */
-	public Activator() {
-	}
-
 	@Override
 	public void start(BundleContext context) throws Exception {
 		super.start(context);
@@ -48,6 +44,60 @@ public class Activator extends AbstractUIPlugin {
 	 */
 	public static Activator getDefault() {
 		return plugin;
+	}
+	
+	/**
+	 * Logs a message for info or debugging purposes.
+	 * 
+	 * @param message
+	 * 			The message to log.
+	 */
+	public static void debug(String message) {
+		getDefault().getLog().log(new Status(IStatus.INFO, ID, message));
+	}
+	
+	/**
+	 * Logs a message for warning the user.
+	 * 
+	 * @param message
+	 * 			The message to log.
+	 */
+	public static void warn(String message) {
+		getDefault().getLog().log(new Status(IStatus.WARNING, ID, message));
+	}
+	
+	/**
+	 * Logs a message for warning the user.
+	 *
+	 * @param t
+	 * 			The throwable that causes the warning.
+	 * @param message
+	 * 			The message to log.
+	 */
+	public static void warn(Throwable t, String message) {
+		getDefault().getLog().log(new Status(IStatus.WARNING, ID, message, t));
+	}
+	
+	/**
+	 * Logs an error.
+	 * 
+	 * @param message
+	 * 			The error message.
+	 */
+	public static void error(String message) {
+		getDefault().getLog().log(new Status(IStatus.ERROR, ID, message));
+	}
+	
+	/**
+	 * Logs an Exception.
+	 * 
+	 * @param e
+	 * 			The exception to log.
+	 * @param message
+	 * 			The error message.
+	 */
+	public static void error(Exception e, String message) {
+		getDefault().getLog().log(new Status(IStatus.ERROR, ID, message, e));
 	}
 
 }

--- a/bundles/fr.kazejiyu.ekumi.ide.ui/src/fr/kazejiyu/ekumi/ide/ui/nature/impl/WorkspaceWorkflowProject.java
+++ b/bundles/fr.kazejiyu.ekumi.ide.ui/src/fr/kazejiyu/ekumi/ide/ui/nature/impl/WorkspaceWorkflowProject.java
@@ -37,19 +37,19 @@ import org.eclipse.sirius.ui.business.internal.commands.ChangeViewpointSelection
 import org.eclipse.sirius.ui.tools.api.project.ModelingProjectManager;
 import org.eclipse.sirius.viewpoint.description.Viewpoint;
 
-import fr.kazejiyu.ekumi.ide.nature.EKumiProject;
-import fr.kazejiyu.ekumi.ide.nature.EKumiProjectNature;
+import fr.kazejiyu.ekumi.ide.nature.WorkflowProject;
+import fr.kazejiyu.ekumi.ide.nature.WorkflowProjectNature;
 import fr.kazejiyu.ekumi.model.spec.Activity;
 import fr.kazejiyu.ekumi.model.spec.SpecFactory;
 import fr.kazejiyu.ekumi.workflow.editor.design.api.EKumiViewpoints;
 
 /**
- * An EKumi project located in the workspace.
+ * A workflow project that is located in the workspace.
  */
 // ChangeViewpointSelectionCommand is not API but even Obeo guys
 // advise to use it since there are no strong alternatives
 @SuppressWarnings("restriction")
-public class WorkspaceEKumiProject implements EKumiProject {
+public class WorkspaceWorkflowProject implements WorkflowProject {
 	
 	/** The workspace containing the project */
 	private final IWorkspace workspace;
@@ -65,7 +65,7 @@ public class WorkspaceEKumiProject implements EKumiProject {
 	 * @param modeling
 	 * 			The manager used to set up the project as a Modeling one.
 	 */
-	public WorkspaceEKumiProject(IWorkspace workspace, ModelingProjectManager modeling) {
+	public WorkspaceWorkflowProject(IWorkspace workspace, ModelingProjectManager modeling) {
 		this.workspace = workspace;
 		this.modeling = modeling;
 	}
@@ -111,8 +111,8 @@ public class WorkspaceEKumiProject implements EKumiProject {
 		String[] newNatures = new String[natures.length + 1];
 		System.arraycopy(natures, 0, newNatures, 0, natures.length);
 
-		// Add EKumi project nature
-		newNatures[natures.length] = EKumiProjectNature.NATURE_ID;
+		// Add Workflow project nature
+		newNatures[natures.length] = WorkflowProjectNature.ID;
 		IStatus status = workspace.validateNatureSet(newNatures);
 
 		// Only apply new natures if the workspace allows it

--- a/bundles/fr.kazejiyu.ekumi.ide.ui/src/fr/kazejiyu/ekumi/ide/ui/wizards/NewActivityPage.java
+++ b/bundles/fr.kazejiyu.ekumi.ide.ui/src/fr/kazejiyu/ekumi/ide/ui/wizards/NewActivityPage.java
@@ -9,6 +9,14 @@
  ******************************************************************************/
 package fr.kazejiyu.ekumi.ide.ui.wizards;
 
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.toSet;
+
+import java.util.Set;
+
+import org.eclipse.jface.viewers.ArrayContentProvider;
+import org.eclipse.jface.viewers.CheckboxTableViewer;
+import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.KeyAdapter;
@@ -19,6 +27,9 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Text;
 
+import fr.kazejiyu.ekumi.model.scripting.ScriptingLanguage;
+import fr.kazejiyu.ekumi.model.spec.Activity;
+
 /**
  * Wizard page used to enter the information required for the creation of a new {@link Activity}.
  */
@@ -26,11 +37,25 @@ public class NewActivityPage extends WizardPage {
 	
 	/** Text box to type the name of the activity to create */
     private Text activityName;
+    
+    /** The languages that can be selected by the user */
+    private final Set<ScriptingLanguage> availableLanguages;
 
-    public NewActivityPage() {
+    /** Displays the list of available languages */
+	private CheckboxTableViewer languagesViewer;
+
+	/**
+	 * Creates a new page allowing the user to type a name and select
+	 * the languages that will be used to implement activities' behavior.
+	 * 
+	 * @param availableLanguages
+	 * 			The languages that can be selected by the user.
+	 */
+    public NewActivityPage(Set<ScriptingLanguage> availableLanguages) {
         super("New Workflow");
         setTitle("New Workflow");
         setDescription("Set up project's workflow");
+        this.availableLanguages = availableLanguages;
     }
 
     @Override
@@ -39,10 +64,50 @@ public class NewActivityPage extends WizardPage {
         GridLayout layout = new GridLayout();
         container.setLayout(layout);
         layout.numColumns = 2;
-        Label activityNameLabel = new Label(container, SWT.NONE);
+        
+        createWorkflowNameTextField(container);
+        createEmptySeparator(container, layout.numColumns);
+        createLanguagesPicker(container, layout.numColumns);
+        
+        // required to avoid an error in the system
+        setControl(container);
+        setPageComplete(false);
+    }
+
+	private void createLanguagesPicker(Composite parent, int numColumns) {
+		Label languagesLabel = new Label(parent, SWT.NONE);
+        languagesLabel.setText("Which languages will be used?");
+        GridData languagesLabelLayout = new GridData(GridData.FILL_HORIZONTAL);
+        languagesLabelLayout.horizontalSpan = numColumns;
+        languagesLabel.setLayoutData(languagesLabelLayout);
+        
+        languagesViewer = CheckboxTableViewer.newCheckList(parent, SWT.BORDER | SWT.MULTI | SWT.FULL_SELECTION);
+        languagesViewer.setLabelProvider(new LabelProvider() {
+			@Override
+			public String getText(Object element) {
+				return ((ScriptingLanguage) element).name();
+			}
+		});
+        languagesViewer.setContentProvider(new ArrayContentProvider());
+        languagesViewer.setInput(availableLanguages);
+        GridData languagesViewerLayout = new GridData(GridData.FILL_HORIZONTAL);
+        languagesViewerLayout.horizontalSpan = 2;
+        languagesViewerLayout.horizontalAlignment = GridData.CENTER;
+        languagesViewer.getTable().setLayoutData(languagesViewerLayout);
+	}
+
+	private static void createEmptySeparator(Composite parent, int numColumns) {
+		Label emptySeparator = new Label(parent, SWT.HORIZONTAL);
+        GridData separatorLayout = new GridData(GridData.FILL_HORIZONTAL);
+        separatorLayout.horizontalSpan = numColumns;
+		emptySeparator.setLayoutData(separatorLayout);
+	}
+
+	private void createWorkflowNameTextField(Composite parent) {
+		Label activityNameLabel = new Label(parent, SWT.NONE);
         activityNameLabel.setText("Workflow name:");
 
-        activityName = new Text(container, SWT.BORDER | SWT.SINGLE);
+        activityName = new Text(parent, SWT.BORDER | SWT.SINGLE);
         activityName.setText("");
         activityName.addKeyListener(new KeyAdapter() {
             @Override
@@ -53,13 +118,7 @@ public class NewActivityPage extends WizardPage {
         });
         GridData gd = new GridData(GridData.FILL_HORIZONTAL);
         activityName.setLayoutData(gd);
-        
-        // required to avoid an error in the system
-        setControl(container);
-        setPageComplete(false);
-
-        activityName.setFocus();
-    }
+	}
     
     @Override
     public void setVisible(boolean visible) {
@@ -85,5 +144,15 @@ public class NewActivityPage extends WizardPage {
      */
     public void setActivityName(String name) {
     	activityName.setText(name);
+    }
+    
+    /**
+     * Returns all the languages that have been selected.
+     * @return all the languages that have been selected 
+     */
+    public Set<ScriptingLanguage> getSelectedLanguages() {
+    	return stream(languagesViewer.getCheckedElements())
+    		  .map(ScriptingLanguage.class::cast)
+    		  .collect(toSet());
     }
 }

--- a/bundles/fr.kazejiyu.ekumi.ide.ui/src/fr/kazejiyu/ekumi/ide/ui/wizards/NewWorkflowProjectWizard.java
+++ b/bundles/fr.kazejiyu.ekumi.ide.ui/src/fr/kazejiyu/ekumi/ide/ui/wizards/NewWorkflowProjectWizard.java
@@ -32,11 +32,11 @@ import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.dialogs.WizardNewProjectCreationPage;
 
 import fr.kazejiyu.ekumi.EKumiPlugin;
-import fr.kazejiyu.ekumi.ide.nature.EKumiProject;
-import fr.kazejiyu.ekumi.ide.ui.nature.impl.WorkspaceEKumiProject;
+import fr.kazejiyu.ekumi.ide.nature.WorkflowProject;
+import fr.kazejiyu.ekumi.ide.ui.nature.impl.WorkspaceWorkflowProject;
 
 /**
- * A wizard used to create new EKumi projects. 
+ * A wizard used to create new workflow projects. 
  */
 public class NewWorkflowProjectWizard extends Wizard implements INewWizard {
 	
@@ -102,7 +102,7 @@ public class NewWorkflowProjectWizard extends Wizard implements INewWizard {
 				@Override
 				public void run(IProgressMonitor monitor) throws InvocationTargetException, InterruptedException {
 					try {
-						EKumiProject project = new WorkspaceEKumiProject(ResourcesPlugin.getWorkspace(), ModelingProjectManager.INSTANCE);
+						WorkflowProject project = new WorkspaceWorkflowProject(ResourcesPlugin.getWorkspace(), ModelingProjectManager.INSTANCE);
 						project.create(projectName, projectLocation, activityName, monitor);
 						
 					} catch (Exception e) {

--- a/bundles/fr.kazejiyu.ekumi.ide/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.ekumi.ide/META-INF/MANIFEST.MF
@@ -6,7 +6,8 @@ Bundle-Version: 0.1.0
 Automatic-Module-Name: fr.kazejiyu.ekumi.ide
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: fr.kazejiyu.ekumi.ide.history,
- fr.kazejiyu.ekumi.ide.nature
+ fr.kazejiyu.ekumi.ide.nature,
+ fr.kazejiyu.ekumi.ide.project.customization
 Require-Bundle: fr.kazejiyu.ekumi.model,
  org.eclipse.e4.core.contexts;bundle-version="1.6.0",
  org.apache.commons.io,

--- a/bundles/fr.kazejiyu.ekumi.ide/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.ekumi.ide/META-INF/MANIFEST.MF
@@ -5,7 +5,8 @@ Bundle-SymbolicName: fr.kazejiyu.ekumi.ide;singleton:=true
 Bundle-Version: 0.1.0
 Automatic-Module-Name: fr.kazejiyu.ekumi.ide
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package: fr.kazejiyu.ekumi.ide.history,
+Export-Package: fr.kazejiyu.ekumi.ide,
+ fr.kazejiyu.ekumi.ide.history,
  fr.kazejiyu.ekumi.ide.nature,
  fr.kazejiyu.ekumi.ide.project.customization
 Require-Bundle: fr.kazejiyu.ekumi.model,

--- a/bundles/fr.kazejiyu.ekumi.ide/plugin.xml
+++ b/bundles/fr.kazejiyu.ekumi.ide/plugin.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.4"?>
 <plugin>
+   <extension-point id="project_customization" name="Project Customization" schema="schema/project_customization.exsd"/>
    <extension
          id="ekumi-nature"
          name="EKumi Project Nature"

--- a/bundles/fr.kazejiyu.ekumi.ide/plugin.xml
+++ b/bundles/fr.kazejiyu.ekumi.ide/plugin.xml
@@ -3,12 +3,12 @@
 <plugin>
    <extension-point id="project_customization" name="Project Customization" schema="schema/project_customization.exsd"/>
    <extension
-         id="ekumi-nature"
-         name="EKumi Project Nature"
+         id="workflow-nature"
+         name="Workflow Project Nature"
          point="org.eclipse.core.resources.natures">
       <runtime>
          <run
-               class="fr.kazejiyu.ekumi.ide.nature.EKumiProjectNature">
+               class="fr.kazejiyu.ekumi.ide.nature.WorkflowProjectNature">
          </run>
       </runtime>
    </extension>

--- a/bundles/fr.kazejiyu.ekumi.ide/schema/project_customization.exsd
+++ b/bundles/fr.kazejiyu.ekumi.ide/schema/project_customization.exsd
@@ -1,0 +1,121 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="fr.kazejiyu.ekumi.ide" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appinfo>
+         <meta.schema plugin="fr.kazejiyu.ekumi.ide" id="languages.project.creation" name="Language Project Creation"/>
+      </appinfo>
+      <documentation>
+         Used to tailor the way EKumi Workflow projects are created.
+
+More specifically, this extension point is supposed to be used to setup the project according to the ScriptingLanguage that will be used in the project, such as by adding specific nature or creating new files.
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appinfo>
+            <meta.element />
+         </appinfo>
+      </annotation>
+      <complexType>
+         <choice minOccurs="1" maxOccurs="unbounded">
+            <element ref="language-specific" minOccurs="1" maxOccurs="unbounded"/>
+         </choice>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute translatable="true"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="language-specific">
+      <annotation>
+         <documentation>
+            The customization of a Workflow project when a specific ScriptingLanguage is selected.
+         </documentation>
+      </annotation>
+      <complexType>
+         <attribute name="language" type="string" use="required">
+            <annotation>
+               <documentation>
+                  ID of the corresponding ScriptingLanguage. 
+
+The customization is used when this language is chosen for a Workflow project.
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="identifier" basedOn="fr.kazejiyu.ekumi.model.languages/language/@id"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+         <attribute name="class" type="string" use="required">
+            <annotation>
+               <documentation>
+                  The class defining how the project is customized.
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn=":fr.kazejiyu.ekumi.ide.project.customization.Customization"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="since"/>
+      </appinfo>
+      <documentation>
+         [Enter the first release in which this extension point appears.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="examples"/>
+      </appinfo>
+      <documentation>
+         [Enter extension point usage example here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="apiinfo"/>
+      </appinfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="implementation"/>
+      </appinfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/EKumiIdePlugin.java
+++ b/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/EKumiIdePlugin.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (C) 2018-2019 Emmanuel CHEBBI
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+package fr.kazejiyu.ekumi.ide;
+
+public final class EKumiIdePlugin {
+	
+	public static final String ID = "fr.kazejiyu.ekumi.ide";
+	
+	public static final String PROJECT_CUSTOMIZATION_EXTENSION_ID = ID + ".project_customization";
+	
+	private EKumiIdePlugin() {
+		// does not make sense to instantiate it
+	}
+
+}

--- a/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/nature/WorkflowProject.java
+++ b/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/nature/WorkflowProject.java
@@ -9,10 +9,14 @@
  ******************************************************************************/
 package fr.kazejiyu.ekumi.ide.nature;
 
+import java.util.Set;
+
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
+
+import fr.kazejiyu.ekumi.ide.project.customization.Customization;
 
 /**
  * <p>An Eclipse IDE project that owns an {@link WorkflowProjectNature}.</p>
@@ -32,13 +36,14 @@ public interface WorkflowProject {
 	 * 			The path of the new project.
 	 * @param activityName
 	 * 			The name of the new activity.
+	 * @param customizations
+	 * 			The objects allow to customize the project after its creation.
 	 * @param monitor
 	 * 			The monitor used to follow the execution. Can be null.
-	 * 
 	 * @return the new project.
 	 * 
 	 * @throws CoreException 
 	 */
-	IProject create(String name, IPath path, String activityName, IProgressMonitor monitor) throws CoreException;
+	IProject create(String name, IPath path, String activityName, Set<Customization> customizations, IProgressMonitor monitor) throws CoreException;
 
 }

--- a/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/nature/WorkflowProject.java
+++ b/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/nature/WorkflowProject.java
@@ -15,13 +15,13 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 
 /**
- * <p>An Eclipse IDE project that owns an {@link EKumiProjectNature}.</p>
+ * <p>An Eclipse IDE project that owns an {@link WorkflowProjectNature}.</p>
  * 
  * <p>Such a project usually contains a specification model serialized under
  * the <i>model/</i> directory as well as a <i>.aird</i> file containing
  * a diagram representation of the model.
  */
-public interface EKumiProject {
+public interface WorkflowProject {
 	
 	/**
 	 * Creates the project.

--- a/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/nature/WorkflowProjectNature.java
+++ b/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/nature/WorkflowProjectNature.java
@@ -16,10 +16,10 @@ import org.eclipse.core.runtime.CoreException;
 /**
  * The nature of a project that hosts EKumi workflows.
  */
-public class EKumiProjectNature implements IProjectNature {
+public class WorkflowProjectNature implements IProjectNature {
 	
 	/** The ID of the nature as defined in the plugin.xml file */
-	public static final String NATURE_ID = "fr.kazejiyu.ekumi.ide.ekumi-nature";
+	public static final String ID = "fr.kazejiyu.ekumi.ide.workflow-nature";
 	
 	private IProject project;
 

--- a/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/project/customization/Customization.java
+++ b/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/project/customization/Customization.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (C) 2018-2019 Emmanuel CHEBBI
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+package fr.kazejiyu.ekumi.ide.project.customization;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+/**
+ * Customizes a given project by adding specific natures or new resources. 
+ */
+public interface Customization {
+	
+	/**
+	 * Customizes the given project.
+	 * @param workspace
+	 * 			The workspace that contains the project.
+	 * @param project
+	 * 			The project to customize.
+	 * @param monitor
+	 * 			The monitor used to follow the progress of the operation.
+	 * 
+	 * @throws CoreException if an error occurs during the customization.
+	 */
+	void customize(IWorkspace workspace, IProject project, IProgressMonitor monitor) throws CoreException;
+
+}

--- a/bundles/fr.kazejiyu.ekumi.languages.java.ide/.classpath
+++ b/bundles/fr.kazejiyu.ekumi.languages.java.ide/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/bundles/fr.kazejiyu.ekumi.languages.java.ide/.project
+++ b/bundles/fr.kazejiyu.ekumi.languages.java.ide/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>fr.kazejiyu.ekumi.languages.java.ide</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/fr.kazejiyu.ekumi.languages.java.ide/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/fr.kazejiyu.ekumi.languages.java.ide/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,7 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/bundles/fr.kazejiyu.ekumi.languages.java.ide/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.ekumi.languages.java.ide/META-INF/MANIFEST.MF
@@ -1,0 +1,14 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: EKumi Java Language — IDE Integration
+Bundle-SymbolicName: fr.kazejiyu.ekumi.languages.java.ide;singleton:=true
+Bundle-Version: 0.1.0
+Bundle-Vendor: Emmanuel CHEBBI
+Automatic-Module-Name: fr.kazejiyu.ekumi.languages.java.ide
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Require-Bundle: fr.kazejiyu.ekumi.ide;bundle-version="0.1.0",
+ fr.kazejiyu.ekumi.languages.java;bundle-version="0.1.0",
+ org.eclipse.core.resources,
+ org.eclipse.core.runtime,
+ org.eclipse.jdt.core,
+ org.eclipse.jdt.launching

--- a/bundles/fr.kazejiyu.ekumi.languages.java.ide/build.properties
+++ b/bundles/fr.kazejiyu.ekumi.languages.java.ide/build.properties
@@ -1,0 +1,5 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .,\
+               plugin.xml

--- a/bundles/fr.kazejiyu.ekumi.languages.java.ide/plugin.xml
+++ b/bundles/fr.kazejiyu.ekumi.languages.java.ide/plugin.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+   <extension
+         point="fr.kazejiyu.ekumi.ide.project_customization">
+      <language-specific
+            class="fr.kazejiyu.ekumi.languages.java.ide.AddPDENature"
+            language="fr.kazejiyu.ekumi.languages.java.JavaLanguage">
+      </language-specific>
+   </extension>
+
+</plugin>

--- a/bundles/fr.kazejiyu.ekumi.languages.java.ide/src/fr/kazejiyu/ekumi/languages/java/ide/AddPDENature.java
+++ b/bundles/fr.kazejiyu.ekumi.languages.java.ide/src/fr/kazejiyu/ekumi/languages/java/ide/AddPDENature.java
@@ -1,0 +1,171 @@
+/*******************************************************************************
+ * Copyright (C) 2018-2019 Emmanuel CHEBBI
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+package fr.kazejiyu.ekumi.languages.java.ide;
+
+import static java.util.Arrays.asList;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.core.resources.ICommand;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.JavaCore;
+
+import fr.kazejiyu.ekumi.ide.project.customization.Customization;
+
+/**
+ * <p>Customizes an IProject by adding the Java and PDE natures</p>  
+ */
+public final class AddPDENature implements Customization {
+
+	@Override
+	public void customize(IWorkspace workspace, IProject project, IProgressMonitor monitor) throws CoreException {
+		SubMonitor subMonitor = SubMonitor.convert(monitor, 5);
+		subMonitor.subTask(""); // otherwise previous sub tasks are displayed
+		subMonitor.setTaskName("Allowing Java");
+		
+		addJavaAndPDENatures(workspace, project, subMonitor.split(1));
+		
+		addBuilders(project.getDescription(), subMonitor.split(1));
+		
+		configureClasspath(project, subMonitor.split(1));
+		
+		writeManifest(project, subMonitor.split(1));
+		writeBuildProperties(project, subMonitor.split(1));
+		
+		subMonitor.setWorkRemaining(0);
+	}
+
+	private static void addJavaAndPDENatures(IWorkspace workspace, IProject project, IProgressMonitor monitor) throws CoreException {
+		monitor.subTask("Adding Java and PDE natures to the project");
+		
+		IProjectDescription description = project.getDescription();
+		Set<String> natures = new HashSet<>(asList(description.getNatureIds()));
+		
+		natures.add(JavaCore.NATURE_ID);
+		natures.add("org.eclipse.pde.PluginNature");
+
+		String[] newNatures = natures.toArray(new String[natures.size()]);
+		IStatus status = workspace.validateNatureSet(newNatures);
+
+		// Only apply new natures if the workspace allows it
+		if (status.getCode() == IStatus.OK) {
+		    description.setNatureIds(newNatures);
+		    project.setDescription(description, null);
+		}
+	}
+
+	private static void addBuilders(IProjectDescription description, IProgressMonitor monitor) {
+		monitor.subTask("Adding Java and PDE builders");
+		
+		ICommand javaBuilder = description.newCommand();
+		javaBuilder.setBuilderName(JavaCore.BUILDER_ID);
+		
+		ICommand manifestBuilder = description.newCommand();
+		manifestBuilder.setBuilderName("org.eclipse.pde.ManifestBuilder");
+		
+		ICommand schemaBuilder = description.newCommand();
+		schemaBuilder.setBuilderName("org.eclipse.pde.SchemaBuilder");
+		
+		Set<ICommand> newBuilders = new HashSet<>();
+		newBuilders.addAll(asList(description.getBuildSpec()));
+		newBuilders.add(javaBuilder);
+		newBuilders.add(manifestBuilder);
+		newBuilders.add(schemaBuilder);
+	}
+
+	private static void configureClasspath(IProject project, IProgressMonitor monitor) throws CoreException {
+		monitor.subTask("Configuring project's classpath");
+		
+		IJavaProject java = JavaCore.create(project);
+		
+		// Create src/ folder
+		IFolder sourceFolder = project.getFolder("src");
+		sourceFolder.create(false, true, null);
+		IPackageFragmentRoot src = java.getPackageFragmentRoot(sourceFolder);
+
+		// Allows Eclipse IDE to resolve dependencies in MANIFEST.MF
+		IClasspathEntry pdeClasspath = JavaCore.newContainerEntry(new Path("org.eclipse.pde.core.requiredPlugins"));
+		// TODO A bit hacky, see https://git.eclipse.org/c/jdt/eclipse.jdt.ui.git/tree/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/wizards/NewJavaProjectWizardPageOne.java#n1258
+		IClasspathEntry jreClasspath = JavaCore.newContainerEntry(new Path("org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"));
+		
+		List<IClasspathEntry> entries = asList(
+			pdeClasspath,
+			jreClasspath,
+			JavaCore.newSourceEntry(src.getPath())
+		);
+		java.setRawClasspath(entries.toArray(new IClasspathEntry[entries.size()]), null);
+	}
+	
+	private static void writeManifest(IProject project, IProgressMonitor monitor) throws CoreException {
+		monitor.subTask("Writing MANIFEST.MF");
+		
+		StringBuilder parameters = new StringBuilder();
+		parameters.append("Manifest-Version: 1.0\n");
+        parameters.append("Bundle-ManifestVersion: 2\n");
+        parameters.append("Bundle-Name: " + project.getName() + "\n");
+        parameters.append("Bundle-SymbolicName: " + project.getName() + "; singleton:=true\n");
+        parameters.append("Bundle-Version: 1.0.0\n");
+        parameters.append("Require-Bundle: fr.kazejiyu.ekumi.model\n");
+        parameters.append("Bundle-RequiredExecutionEnvironment: JavaSE-1.8\n");
+        parameters.append("Bundle-ActivationPolicy: lazy\n");
+        parameters.append("Automatic-Module-Name: " + project.getName() + "\n");
+
+        IFolder metaInf = project.getFolder("META-INF");
+        metaInf.create(false, true, null);
+        
+        IFile manifest = metaInf.getFile("MANIFEST.MF");
+        InputStream content = new ByteArrayInputStream(parameters.toString().getBytes(StandardCharsets.UTF_8));
+        manifest.create(content, true, null);
+	}
+	
+	private static void writeBuildProperties(IProject project, IProgressMonitor monitor) throws CoreException {
+		monitor.subTask("Writing build.properties");
+		
+		StringBuilder properties = new StringBuilder();
+		properties.append("source.. = src/\n");
+        properties.append("output.. = bin/\n");
+        properties.append("bin.includes = .,\\\n");
+        properties.append("               META-INF/\n");
+
+        IFile buildProperties = project.getFile("build.properties");
+        InputStream content = new ByteArrayInputStream(properties.toString().getBytes(StandardCharsets.UTF_8));
+        buildProperties.create(content, true, null);
+	}
+	
+	@Override
+	public boolean equals(Object other) {
+		if (other == null)
+			return false;
+		return getClass().equals(other.getClass());
+	}
+	
+	@Override
+	public int hashCode() {
+		return getClass().hashCode();
+	}
+
+}

--- a/bundles/fr.kazejiyu.ekumi.languages.java/plugin.xml
+++ b/bundles/fr.kazejiyu.ekumi.languages.java/plugin.xml
@@ -5,6 +5,7 @@
          point="fr.kazejiyu.ekumi.model.languages">
       <language
             class="fr.kazejiyu.ekumi.languages.java.JavaLanguage"
+            id="fr.kazejiyu.ekumi.languages.java.JavaLanguage"
             name="Java"></language>
    </extension>
 

--- a/bundles/fr.kazejiyu.ekumi.languages.java/src/fr/kazejiyu/ekumi/languages/java/JavaLanguage.java
+++ b/bundles/fr.kazejiyu.ekumi.languages.java/src/fr/kazejiyu/ekumi/languages/java/JavaLanguage.java
@@ -69,7 +69,7 @@ import fr.kazejiyu.ekumi.model.workflow.Script;
 public final class JavaLanguage implements ScriptingLanguage {
 	
 	/** The id of the extension providing this scripting language */
-	public static final String EXTENSION_ID = "fr.kazejiyu.ekumi.languages.java";
+	public static final String EXTENSION_ID = "fr.kazejiyu.ekumi.languages.java.JavaLanguage";
 	
 	@Override
 	public String id() {

--- a/bundles/fr.kazejiyu.ekumi.model/schema/languages.exsd
+++ b/bundles/fr.kazejiyu.ekumi.model/schema/languages.exsd
@@ -51,6 +51,13 @@ A programming language is represented by an instance of ScriptingLanguage, which
 
    <element name="language">
       <complexType>
+         <attribute name="id" type="string" use="required">
+            <annotation>
+               <documentation>
+                  Uniquely identifies this language.
+               </documentation>
+            </annotation>
+         </attribute>
          <attribute name="name" type="string" use="required">
             <annotation>
                <documentation>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -22,6 +22,7 @@
         <module>fr.kazejiyu.ekumi.ide.events</module>
         <module>fr.kazejiyu.ekumi.ide.ui</module>
         <module>fr.kazejiyu.ekumi.languages.java</module>
+        <module>fr.kazejiyu.ekumi.languages.java.ide</module>
         <module>fr.kazejiyu.ekumi.model</module>
         <module>fr.kazejiyu.ekumi.model.edit</module>
         <module>fr.kazejiyu.ekumi.model.editor</module>


### PR DESCRIPTION
The `project_customization` allows creators of ScriptingLanguage implementations to add post-processing to the NewWorkflowProjectWizard.

This feature can be used to, for example, create files, add natures or configure classpath.

It is currently used by the JavaLanguage implementation in order to modify new Workflow projects by:

- adding the Java and PDE natures,
- configuring the classpath,
- creating the `MANIFEST.MF` and `build.properties` files.