### PR TITLE
Make refs/remotes/origin known to SonarCloud

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,10 @@ install: true
 before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
+  - sleep 10 # give xvfb some time to start
   - git fetch --unshallow
+  - git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+  - git fetch origin
   # Prevent installed packages from being used during build
   - rm -rfv "$HOME/.m2/repository/fr/kazejiyu/ekumi/"
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,23 @@
+sonar.projectName=EKumi
+
+# =====================================================
+#   Meta-data for the project
+# =====================================================
+
+sonar.links.homepage=https://github.com/KazeJiyu/ekumi
+sonar.links.ci=https://travis-ci.org/KazeJiyu/ekumi
+sonar.links.scm=https://github.com/KazeJiyu/ekumi
+sonar.links.issue=https://github.com/KazeJiyu/ekumi/issues
+
+
+# =====================================================
+#   Properties that will be shared amongst all modules
+# =====================================================
+
+sonar.host.url=https://sonarcloud.io
+
+# =====================================================
+#   Java config
+# =====================================================
+
+sonar.java.source=8


### PR DESCRIPTION
SonarCloud gives warnings like "Could not find ref 'master' in refs/heads or refs/remotes/origin".
It may be the reason why it is not decorating PR anymore, so here is an attempt to fix the issue.