### PR TITLE
Allow workflow's editor to be extended

### DIFF
--- a/bundles/fr.kazejiyu.ekumi.ide.common/src/fr/kazejiyu/ekumi/ide/common/datatypes/ExtensionToDatatypeAdapter.java
+++ b/bundles/fr.kazejiyu.ekumi.ide.common/src/fr/kazejiyu/ekumi/ide/common/datatypes/ExtensionToDatatypeAdapter.java
@@ -19,7 +19,7 @@ import java.util.function.Function;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 
-import fr.kazejiyu.ekumi.core.catalog.Catalogs;
+import fr.kazejiyu.ekumi.core.EKumiPlugin;
 import fr.kazejiyu.ekumi.core.datatypes.DataType;
 import fr.kazejiyu.ekumi.ide.common.Activator;
 
@@ -41,12 +41,12 @@ import fr.kazejiyu.ekumi.ide.common.Activator;
 public class ExtensionToDatatypeAdapter {
 	
 	/**
-	 * Creates a new {@link Catalogs} according to the given configuration elements.
+	 * Creates new {@link DataType} according to the given configuration elements.
 	 * 
 	 * @param configurationElements
 	 * 			The configuration elements describing user extensions.
 	 * 
-	 * @return a new Catalogs instance.
+	 * @return DataTypes objects instantiated from given elements
 	 */
 	public List<DataType<?>> adapt(List<IConfigurationElement> configurationElements) {
 		requireNonNull(configurationElements, "Cannot adapt null configuration elements");
@@ -54,7 +54,6 @@ public class ExtensionToDatatypeAdapter {
 		return configurationElements.stream()
 									.map(toDataType())
 									.filter(Objects::nonNull)
-									.map(DataType.class::cast)
 									.collect(toList());
 	}
 	

--- a/bundles/fr.kazejiyu.ekumi.ide.common/src/fr/kazejiyu/ekumi/ide/common/languages/ExtensionToScriptingLanguageAdapter.java
+++ b/bundles/fr.kazejiyu.ekumi.ide.common/src/fr/kazejiyu/ekumi/ide/common/languages/ExtensionToScriptingLanguageAdapter.java
@@ -47,7 +47,6 @@ public class ExtensionToScriptingLanguageAdapter {
 		return configurationElements.stream()
 									.map(toLanguage())
 									.filter(Objects::nonNull)
-									.map(ScriptingLanguage.class::cast)
 									.collect(toList());
 	}
 	

--- a/bundles/fr.kazejiyu.ekumi.ide.common/src/fr/kazejiyu/ekumi/ide/common/spec/ExtensionToActivityAdapterAdapter.java
+++ b/bundles/fr.kazejiyu.ekumi.ide.common/src/fr/kazejiyu/ekumi/ide/common/spec/ExtensionToActivityAdapterAdapter.java
@@ -55,7 +55,6 @@ public class ExtensionToActivityAdapterAdapter {
 		return configurationElements.stream()
 									.map(toActivityAdapter())
 									.filter(Objects::nonNull)
-									.map(ActivityAdapter.class::cast)
 									.collect(toList());
 	}
 	

--- a/bundles/fr.kazejiyu.ekumi.ide.ui/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.ekumi.ide.ui/META-INF/MANIFEST.MF
@@ -4,20 +4,11 @@ Bundle-Name: EKumi IDE UI
 Bundle-SymbolicName: fr.kazejiyu.ekumi.ide.ui;singleton:=true
 Bundle-Version: 0.1.0
 Bundle-Activator: fr.kazejiyu.ekumi.ide.ui.Activator
-Require-Bundle: org.eclipse.ui,
- org.eclipse.core.runtime,
- org.eclipse.ui.ide,
+Require-Bundle: org.eclipse.ui;bundle-version="[3.109.0,4.0.0)",
+ org.eclipse.ui.ide;bundle-version="[3.13.1,4.0.0)",
  fr.kazejiyu.ekumi.ide;bundle-version="0.1.0",
- org.eclipse.core.resources,
- org.eclipse.emf.ecore,
- org.eclipse.sirius,
- org.eclipse.emf.transaction,
- org.eclipse.sirius.ui,
- org.eclipse.sirius.ext.base,
- fr.kazejiyu.ekumi.specs.eds.design;bundle-version="0.1.0",
- fr.kazejiyu.ekumi.core;bundle-version="0.1.0",
- fr.kazejiyu.ekumi.specs.eds
+ org.eclipse.emf.transaction;bundle-version="[1.9.0,2.0.0)",
+ fr.kazejiyu.ekumi.core;bundle-version="0.1.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: fr.kazejiyu.ekumi.ide.ui
 Bundle-ActivationPolicy: lazy
-Import-Package: org.eclipse.sirius.ui.tools.api.project

--- a/bundles/fr.kazejiyu.ekumi.ide.ui/src/fr/kazejiyu/ekumi/ide/ui/nature/impl/WorkspaceWorkflowProject.java
+++ b/bundles/fr.kazejiyu.ekumi.ide.ui/src/fr/kazejiyu/ekumi/ide/ui/nature/impl/WorkspaceWorkflowProject.java
@@ -9,12 +9,6 @@
  ******************************************************************************/
 package fr.kazejiyu.ekumi.ide.ui.nature.impl;
 
-import static java.util.Arrays.asList;
-
-import java.io.IOException;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Optional;
 import java.util.Set;
 
 import org.eclipse.core.resources.IProject;
@@ -25,65 +19,39 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
-import org.eclipse.emf.common.util.URI;
-import org.eclipse.emf.ecore.resource.Resource;
-import org.eclipse.emf.ecore.resource.ResourceSet;
-import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
-import org.eclipse.emf.transaction.RecordingCommand;
-import org.eclipse.sirius.business.api.modelingproject.ModelingProject;
-import org.eclipse.sirius.business.api.session.Session;
-import org.eclipse.sirius.ui.business.api.viewpoint.ViewpointSelectionCallback;
-import org.eclipse.sirius.ui.business.internal.commands.ChangeViewpointSelectionCommand;
-import org.eclipse.sirius.ui.tools.api.project.ModelingProjectManager;
-import org.eclipse.sirius.viewpoint.description.Viewpoint;
 
 import fr.kazejiyu.ekumi.ide.nature.WorkflowProject;
 import fr.kazejiyu.ekumi.ide.nature.WorkflowProjectNature;
 import fr.kazejiyu.ekumi.ide.project.customization.Customization;
-import fr.kazejiyu.ekumi.specs.eds.Activity;
-import fr.kazejiyu.ekumi.specs.eds.EdsFactory;
-import fr.kazejiyu.ekumi.specs.eds.design.api.EKumiViewpoints;
 
 /**
  * A workflow project that is located in the workspace.
  */
-// ChangeViewpointSelectionCommand is not API but even Obeo guys
-// advise to use it since there are no strong alternatives
-@SuppressWarnings("restriction")
 public class WorkspaceWorkflowProject implements WorkflowProject {
 	
 	/** The workspace containing the project */
 	private final IWorkspace workspace;
-	
-	/** Used to set up the project as a Modeling one */
-	private final ModelingProjectManager modeling;
 	
 	/**
 	 * Creates a new instance.
 	 * 
 	 * @param workspace
 	 * 			The workspace containing the project.
-	 * @param modeling
-	 * 			The manager used to set up the project as a Modeling one.
 	 */
-	public WorkspaceWorkflowProject(IWorkspace workspace, ModelingProjectManager modeling) {
+	public WorkspaceWorkflowProject(IWorkspace workspace) {
 		this.workspace = workspace;
-		this.modeling = modeling;
 	}
 
 	@Override
 	public IProject create(String name, IPath path, String activityName, Set<Customization> customizations, IProgressMonitor monitor) throws CoreException {
 		IWorkspaceRunnable createProject = projectMonitor -> {
-			SubMonitor subMonitor = SubMonitor.convert(monitor, 3 + customizations.size());
+			SubMonitor subMonitor = SubMonitor.convert(monitor, 1 + customizations.size());
 			
-			IProject project = createProject(name, path, subMonitor.split(1));
-            Activity workflow = createProjectModel(activityName, project, subMonitor.split(1));
-            createRepresentation(workflow, project, subMonitor.split(1));
+			IProject project = createProject(name, subMonitor.split(1));
                 
             for (Customization customization : customizations) {
-				customization.customize(workspace, project, subMonitor.split(1));
+				customization.customize(activityName, workspace, project, subMonitor.split(1));
 			}
 		};
 		workspace.run(createProject, monitor);
@@ -95,137 +63,32 @@ public class WorkspaceWorkflowProject implements WorkflowProject {
 	 * 
 	 * @param name
 	 * 			The name of the project to create.
-	 * @param path
-	 * 			The location of the project to create.
 	 * @param monitor
 	 * 			The monitor used to show progression of the creation.
-	 * 
 	 * @return the new project
 	 * 
 	 * @throws CoreException if an error occurs while creating the project
 	 */
-	private IProject createProject(String name, IPath path, IProgressMonitor monitor) throws CoreException {
+	private IProject createProject(String name, IProgressMonitor monitor) throws CoreException {
 		SubMonitor subMonitor = SubMonitor.convert(monitor);
 		subMonitor.setTaskName("Creating the project");
 		
-		// First add the Modeling nature to the project
-		IProject project = modeling.createNewModelingProject(name, path, true, monitor);
+		// First create the project in the workspace
+		IProject project = workspace.getRoot().getProject(name);
+		project.create(null);
+		project.open(null);
 		
-		IProjectDescription description = project.getDescription();
-		String[] natures = description.getNatureIds();
-		String[] newNatures = new String[natures.length + 1];
-		System.arraycopy(natures, 0, newNatures, 0, natures.length);
+		// Prepare the Workflow project nature 
+		String[] natures = new String[] { WorkflowProjectNature.ID };
+		IStatus status = workspace.validateNatureSet(natures);
 
-		// Add Workflow project nature
-		newNatures[natures.length] = WorkflowProjectNature.ID;
-		IStatus status = workspace.validateNatureSet(newNatures);
-
-		// Only apply new natures if the workspace allows it
+		// Only actually apply new natures if the workspace allows it
 		if (status.getCode() == IStatus.OK) {
-		    description.setNatureIds(newNatures);
+			IProjectDescription description = project.getDescription();
+			description.setNatureIds(natures);
 		    project.setDescription(description, null);
 		}
 		return project;
-	}
-
-	/**
-	 * Creates a new Activity model and saves it under the given project's location.
-	 * @param activityName
-	 * 			The name of the model to create.
-	 * @param project
-	 * 			The project in which the model is persisted.
-	 * @param monitor
-	 * 			The 
-	 * 
-	 * @return the new model
-	 * 
-	 * @throws CoreException if the new model cannot be persisted
-	 */
-	private static Activity createProjectModel(String activityName, IProject project, IProgressMonitor monitor) throws CoreException {
-		SubMonitor subMonitor = SubMonitor.convert(monitor);
-		subMonitor.setTaskName("Creating the workflow model");
-		
-		// Create the Activity representing the workflow
-		Activity workflow = EdsFactory.eINSTANCE.createActivity();
-		workflow.setId(project.getName() + "." + activityName);
-		workflow.setName(activityName);
-		workflow.setStart(EdsFactory.eINSTANCE.createStart());
-		
-		// Save the Activity in a resource 'model/activity.spec'
-		ResourceSet resourceSet = new ResourceSetImpl();
-		Resource workflowResource = resourceSet.createResource(URI.createURI(project.getFile("model/" + activityName + ".eds").getLocationURI().toString()));
-		workflowResource.getContents().add(workflow);
-		
-		try {
-			workflowResource.save(Collections.emptyMap());
-		} 
-		catch (IOException e) {
-			Status error = new Status(IStatus.ERROR, "fr.kazejiyu.ekumi.ide", "An error occured while creating " + workflowResource.getURI(), e);
-			throw new CoreException(error);
-		}
-		return workflow;
-	}
-
-	/**
-	 * Create a diagram representation of the given activity.
-	 * 
-	 * @param model
-	 * 			The semantic model of the presentation.
-	 * @param project
-	 * 			The project in which the representation is created.
-	 * @param monitor
-	 * 			The monitor used to show progression of the creation. 
-	 * 
-	 * @throws CoreException
-	 */
-	private static void createRepresentation(Activity model, IProject project, IProgressMonitor monitor) throws CoreException {
-		SubMonitor subMonitor = SubMonitor.convert(monitor);
-		subMonitor.setTaskName("Creating the diagram");
-		
-		// Create a new Sirius session to handle the representation
-		Session session = ModelingProject.asModelingProject(project).get().getSession();
-		
-		// Allow to create a representation for the activity thereafter
-		session.getTransactionalEditingDomain().getCommandStack()
-			   .execute(new RecordingCommand(session.getTransactionalEditingDomain()) {
-				   @Override
-				   protected void doExecute() {
-					   SubMonitor commandMonitor = SubMonitor.convert(subMonitor);
-					   session.addSemanticResource(model.eResource().getURI(), commandMonitor);
-				   }
-			   });
-		
-		Viewpoint workflowViewpoint = workflowViewpoint();
-		
-		ChangeViewpointSelectionCommand cc = new ChangeViewpointSelectionCommand(session, new ViewpointSelectionCallback(), new HashSet<>(asList(workflowViewpoint)), Collections.emptySet(), monitor);
-		session.getTransactionalEditingDomain().getCommandStack().execute(cc);
-		
-		session.getTransactionalEditingDomain().getCommandStack()
-			   .execute(new RecordingCommand(session.getTransactionalEditingDomain()) {
-					@Override
-					protected void doExecute() {
-						SubMonitor commandMonitor = SubMonitor.convert(subMonitor);
-						session.createView(workflowViewpoint, asList(model), true, commandMonitor);
-					}
-			   });
-	}
-
-	/**
-	 * Returns the 'EKumi Workflow' viewpoint.
-	 * 
-	 * @return the viewpoint defining representations for workflows
-	 * 
-	 * @throws CoreException if the viewpoint cannot be found
-	 */
-	private static Viewpoint workflowViewpoint() throws CoreException {
-		// Find the 'EKumi Workflow' viewpoint
-		Optional<Viewpoint> workflowViewpoint = EKumiViewpoints.workflow();
-		
-		if ( ! workflowViewpoint.isPresent()) {
-			Status error = new Status(IStatus.ERROR, "fr.kazejiyu.ekumi.ide.ui", "Cannot find EKumi's workflow editor viewpoint. Check that fr.kazejiyu.ekumi.specs.eds.design plug-in is available.");
-			throw new CoreException(error);
-		}
-		return workflowViewpoint.get();
 	}
 
 }

--- a/bundles/fr.kazejiyu.ekumi.ide/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.ekumi.ide/META-INF/MANIFEST.MF
@@ -20,3 +20,4 @@ Require-Bundle: org.eclipse.e4.core.contexts;bundle-version="1.6.0",
 Service-Component: OSGI-INF/history.xml,
  OSGI-INF/catalogs.xml
 Bundle-ActivationPolicy: lazy
+Bundle-Activator: fr.kazejiyu.ekumi.ide.EKumiIdePlugin

--- a/bundles/fr.kazejiyu.ekumi.ide/schema/project_customization.exsd
+++ b/bundles/fr.kazejiyu.ekumi.ide/schema/project_customization.exsd
@@ -3,12 +3,16 @@
 <schema targetNamespace="fr.kazejiyu.ekumi.ide" xmlns="http://www.w3.org/2001/XMLSchema">
 <annotation>
       <appinfo>
-         <meta.schema plugin="fr.kazejiyu.ekumi.ide" id="languages.project.creation" name="Language Project Creation"/>
+         <meta.schema plugin="fr.kazejiyu.ekumi.ide" id="project_customization" name="Workflow Project Customization"/>
       </appinfo>
       <documentation>
          Used to tailor the way EKumi Workflow projects are created.
 
-More specifically, this extension point is supposed to be used to setup the project according to the ScriptingLanguage that will be used in the project, such as by adding specific nature or creating new files.
+More specifically, this extension point is supposed to be used to setup the project according to its settings:
+ - the ScriptingLanguage that will be used in the project, 
+ - the chosen Representation.
+ 
+ The project can be setup by, for instance, adding specific nature or creating new files.
       </documentation>
    </annotation>
 
@@ -21,6 +25,7 @@ More specifically, this extension point is supposed to be used to setup the proj
       <complexType>
          <choice minOccurs="1" maxOccurs="unbounded">
             <element ref="language-specific" minOccurs="1" maxOccurs="unbounded"/>
+            <element ref="representation" minOccurs="1" maxOccurs="unbounded"/>
          </choice>
          <attribute name="point" type="string" use="required">
             <annotation>
@@ -75,6 +80,49 @@ The customization is used when this language is chosen for a Workflow project.
                </documentation>
                <appinfo>
                   <meta.attribute kind="java" basedOn=":fr.kazejiyu.ekumi.ide.project.customization.Customization"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="representation">
+      <annotation>
+         <documentation>
+            A representation of an Activity.
+ 
+A representation is not necessarily visual: it may be textual or in-memory.
+         </documentation>
+      </annotation>
+      <complexType>
+         <attribute name="id" type="string" use="required">
+            <annotation>
+               <documentation>
+                  Uniquely identifies the representation.
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  A human-readable name of the representation.
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="description" type="string">
+            <annotation>
+               <documentation>
+                  An explanation of what the representation looks like.
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="class" type="string" use="required">
+            <annotation>
+               <documentation>
+                  The implementation of this representation.
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn=":fr.kazejiyu.ekumi.ide.project.customization.Representation"/>
                </appinfo>
             </annotation>
          </attribute>

--- a/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/EKumiIdeExtensions.java
+++ b/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/EKumiIdeExtensions.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (C) 2018-2019 Emmanuel CHEBBI
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+package fr.kazejiyu.ekumi.ide;
+
+public final class EKumiIdeExtensions {
+	
+	/** ID of the 'project_customization' extension point */
+	public static final String PROJECT_CUSTOMIZATION_EXTENSION_ID = EKumiIdePlugin.ID + ".project_customization";
+	
+	private EKumiIdeExtensions() {
+		// makes no sense to instantiate it
+	}
+
+}

--- a/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/EKumiIdePlugin.java
+++ b/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/EKumiIdePlugin.java
@@ -9,14 +9,89 @@
  ******************************************************************************/
 package fr.kazejiyu.ekumi.ide;
 
-public final class EKumiIdePlugin {
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Plugin;
+import org.eclipse.core.runtime.Status;
+import org.osgi.framework.BundleContext;
+
+public final class EKumiIdePlugin extends Plugin {
 	
 	public static final String ID = "fr.kazejiyu.ekumi.ide";
 	
-	public static final String PROJECT_CUSTOMIZATION_EXTENSION_ID = ID + ".project_customization";
+	// The shared instance
+	private static EKumiIdePlugin plugin;
+
+	@Override
+	public void start(BundleContext context) throws Exception {
+		plugin = this;
+	}
+
+	@Override
+	public void stop(BundleContext context) throws Exception {
+		plugin = null;
+	}
+
+	/**
+	 * Returns the shared instance
+	 *
+	 * @return the shared instance
+	 */
+	public static EKumiIdePlugin getDefault() {
+		return plugin;
+	}
 	
-	private EKumiIdePlugin() {
-		// does not make sense to instantiate it
+	/**
+	 * Logs a message for info or debugging purposes.
+	 * 
+	 * @param message
+	 * 			The message to log.
+	 */
+	public static void debug(String message) {
+		getDefault().getLog().log(new Status(IStatus.INFO, ID, message));
+	}
+	
+	/**
+	 * Logs a message for warning the user.
+	 * 
+	 * @param message
+	 * 			The message to log.
+	 */
+	public static void warn(String message) {
+		getDefault().getLog().log(new Status(IStatus.WARNING, ID, message));
+	}
+	
+	/**
+	 * Logs a message for warning the user providing an additional stack trace.
+	 * 
+	 * @param t
+	 * 			The throwable that causes the warning.
+	 * @param message
+	 * 			The message to log.
+	 */
+	public static void warn(Throwable t, String message) {
+		getDefault().getLog().log(new Status(IStatus.WARNING, ID, message, t));
+	}
+	
+	/**
+	 * Logs an error.
+	 * 
+	 * @param message
+	 * 			The error message.
+	 */
+	public static void error(String message) {
+		getDefault().getLog().log(new Status(IStatus.ERROR, ID, message));
+	}
+	
+	/**
+	 * Logs an Exception.
+	 * 
+	 * @param e
+	 * 			The exception to log.
+	 * @param message
+	 * 			The error message.
+	 */
+	public static void error(Exception e, String message) {
+		getDefault().getLog().log(new Status(IStatus.ERROR, ID, message, e));
 	}
 
 }

--- a/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/project/customization/Customization.java
+++ b/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/project/customization/Customization.java
@@ -21,6 +21,9 @@ public interface Customization {
 	
 	/**
 	 * Customizes the given project.
+	 * 
+	 * @param activityName
+	 * 			The name of the activity.
 	 * @param workspace
 	 * 			The workspace that contains the project.
 	 * @param project
@@ -30,6 +33,6 @@ public interface Customization {
 	 * 
 	 * @throws CoreException if an error occurs during the customization.
 	 */
-	void customize(IWorkspace workspace, IProject project, IProgressMonitor monitor) throws CoreException;
+	void customize(String activityName, IWorkspace workspace, IProject project, IProgressMonitor monitor) throws CoreException;
 
 }

--- a/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/project/customization/Representation.java
+++ b/bundles/fr.kazejiyu.ekumi.ide/src/fr/kazejiyu/ekumi/ide/project/customization/Representation.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (C) 2018-2019 Emmanuel CHEBBI
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+package fr.kazejiyu.ekumi.ide.project.customization;
+
+import fr.kazejiyu.ekumi.core.workflow.Activity;
+
+/**
+ * <p>A representation of an {@link Activity}.</p>
+ * 
+ * <p>A representation is not necessarily visual: it may be textual or in-memory.</p>
+ */
+public interface Representation extends Customization {
+	
+	/**
+	 * Returns the ID of the representation.
+	 * @return a unique identifier
+	 */
+	String id();
+	
+	/**
+	 * Returns the name of the representation.
+	 * @return a human-readable name
+	 */
+	String name();
+	
+	/**
+	 * Returns the description of the representation.
+	 * @return the description of the representation
+	 */
+	String description();
+
+}

--- a/bundles/fr.kazejiyu.ekumi.languages.java.ide/src/fr/kazejiyu/ekumi/languages/java/ide/AddPDENature.java
+++ b/bundles/fr.kazejiyu.ekumi.languages.java.ide/src/fr/kazejiyu/ekumi/languages/java/ide/AddPDENature.java
@@ -42,7 +42,7 @@ import fr.kazejiyu.ekumi.ide.project.customization.Customization;
 public final class AddPDENature implements Customization {
 
 	@Override
-	public void customize(IWorkspace workspace, IProject project, IProgressMonitor monitor) throws CoreException {
+	public void customize(String activityName, IWorkspace workspace, IProject project, IProgressMonitor monitor) throws CoreException {
 		SubMonitor subMonitor = SubMonitor.convert(monitor, 5);
 		subMonitor.subTask(""); // otherwise previous sub tasks are displayed
 		subMonitor.setTaskName("Allowing Java");

--- a/bundles/fr.kazejiyu.ekumi.specs.eds.design/META-INF/MANIFEST.MF
+++ b/bundles/fr.kazejiyu.ekumi.specs.eds.design/META-INF/MANIFEST.MF
@@ -19,7 +19,9 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.ide,
  fr.kazejiyu.ekumi.ide.common;bundle-version="0.1.0",
  fr.kazejiyu.ekumi.core;bundle-version="0.1.0",
- fr.kazejiyu.ekumi.specs.eds;bundle-version="0.1.0"
+ fr.kazejiyu.ekumi.specs.eds;bundle-version="0.1.0",
+ fr.kazejiyu.ekumi.ide;bundle-version="0.1.0",
+ org.eclipse.sirius.ext.base
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: %providerName

--- a/bundles/fr.kazejiyu.ekumi.specs.eds.design/plugin.xml
+++ b/bundles/fr.kazejiyu.ekumi.specs.eds.design/plugin.xml
@@ -16,4 +16,13 @@
            label="Legacy Sirius Tabs Filter for EKumi models">
      </descriptor>
   </extension>
+  <extension
+        point="fr.kazejiyu.ekumi.ide.project_customization">
+     <representation
+           class="fr.kazejiyu.ekumi.specs.eds.design.EdsSiriusRepresentation"
+           description="A BPMN-inspired workflow diagram editor"
+           id="fr.kazejiyu.ekumi.specs.eds.design.EdsSiriusRepresentation"
+           name="EKumi Default Representation">
+     </representation>
+  </extension>
 </plugin>

--- a/bundles/fr.kazejiyu.ekumi.specs.eds.design/src/fr/kazejiyu/ekumi/specs/eds/design/EdsSiriusRepresentation.java
+++ b/bundles/fr.kazejiyu.ekumi.specs.eds.design/src/fr/kazejiyu/ekumi/specs/eds/design/EdsSiriusRepresentation.java
@@ -1,0 +1,204 @@
+/*******************************************************************************
+ * Copyright (C) 2018-2019 Emmanuel CHEBBI
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+package fr.kazejiyu.ekumi.specs.eds.design;
+
+import static java.util.Arrays.asList;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.eclipse.emf.transaction.RecordingCommand;
+import org.eclipse.sirius.business.api.modelingproject.ModelingProject;
+import org.eclipse.sirius.business.api.session.Session;
+import org.eclipse.sirius.ui.business.api.viewpoint.ViewpointSelectionCallback;
+import org.eclipse.sirius.ui.business.internal.commands.ChangeViewpointSelectionCommand;
+import org.eclipse.sirius.ui.tools.api.project.ModelingProjectManager;
+import org.eclipse.sirius.viewpoint.description.Viewpoint;
+
+import fr.kazejiyu.ekumi.ide.project.customization.Representation;
+import fr.kazejiyu.ekumi.specs.eds.Activity;
+import fr.kazejiyu.ekumi.specs.eds.EdsFactory;
+import fr.kazejiyu.ekumi.specs.eds.design.api.EKumiViewpoints;
+
+/**
+ * <p>A visual representation of the EKumi Default Specification based on Sirius.</p>
+ * 
+ * <p>This representation is a BPMN-inspired workflow diagram editor.</p>
+ */
+//ChangeViewpointSelectionCommand is not API but even Obeo guys
+//advise to use it since there are no strong alternatives
+@SuppressWarnings("restriction")
+public class EdsSiriusRepresentation implements Representation {
+	
+	@Override
+	public String id() {
+		return getClass().getCanonicalName();
+	}
+
+	@Override
+	public String name() {
+		return "EKumi Default Representation";
+	}
+
+	@Override
+	public String description() {
+		return "A BPMN-inspired workflow diagram editor";
+	}
+
+	/**
+	 * <p>Customizes the project by adding a Sirius representation of the specification's model.</p>
+	 * 
+	 * <p>In order to be customized, the project must:
+	 * 	<ul>
+	 * 		<li>contain an EDS model under {@code model/*.eds}</li>
+	 * 	</ul>
+	 * <p>
+	 * 
+	 * <p>If the project does not have the Sirius' Modeling nature, then the nature is added.</p>
+	 */
+	@Override
+	public void customize(String activityName, IWorkspace workspace, IProject project, IProgressMonitor monitor) throws CoreException {
+		SubMonitor subMonitor = SubMonitor.convert(monitor, 3);
+		
+		ensureHasModelingNature(project, subMonitor.split(1));
+		Activity activity = createActivity(activityName, project, subMonitor.split(1));
+		createRepresentation(activity, project, subMonitor.split(1));
+	}
+
+	/**
+	 * Creates a new Activity model and saves it under the given project's location.
+	 * 
+	 * @param activityName
+	 * 			The name of the model to create.
+	 * @param project
+	 * 			The project in which the model is persisted.
+	 * @param monitor
+	 * 			The instance monitor the execution. 
+	 * 
+	 * @return the new activity
+	 * 
+	 * @throws CoreException if the new model cannot be persisted
+	 */
+	private static Activity createActivity(String activityName, IProject project, IProgressMonitor monitor) throws CoreException {
+		SubMonitor subMonitor = SubMonitor.convert(monitor);
+		subMonitor.setTaskName("Creating the workflow model");
+		
+		// Create the Activity representing the workflow
+		Activity workflow = EdsFactory.eINSTANCE.createActivity();
+		workflow.setId(project.getName() + "." + activityName);
+		workflow.setName(activityName);
+		workflow.setStart(EdsFactory.eINSTANCE.createStart());
+		
+		// Save the Activity in a resource 'model/activity.spec'
+		ResourceSet resourceSet = new ResourceSetImpl();
+		Resource workflowResource = resourceSet.createResource(URI.createURI(project.getFile("model/" + activityName + ".eds").getLocationURI().toString()));
+		workflowResource.getContents().add(workflow);
+		
+		try {
+			workflowResource.save(Collections.emptyMap());
+		} 
+		catch (IOException e) {
+			Status error = new Status(IStatus.ERROR, "fr.kazejiyu.ekumi.ide", "An error occured while creating " + workflowResource.getURI(), e);
+			throw new CoreException(error);
+		}
+		return workflow;
+	}
+
+	/**
+	 * Create a diagram representation of the given activity.
+	 * 
+	 * @param model
+	 * 			The semantic model of the presentation.
+	 * @param project
+	 * 			The project in which the representation is created.
+	 * @param monitor
+	 * 			The monitor used to show progression of the creation. 
+	 * 
+	 * @throws CoreException
+	 */
+	private static void createRepresentation(Activity model, IProject project, IProgressMonitor monitor) throws CoreException {
+		SubMonitor subMonitor = SubMonitor.convert(monitor);
+		subMonitor.setTaskName("Creating the diagram");
+		
+		// Create a new Sirius session to handle the representation
+		Session session = ModelingProject.asModelingProject(project).get().getSession();
+		
+		// Allow to create a representation for the activity thereafter
+		session.getTransactionalEditingDomain().getCommandStack()
+			   .execute(new RecordingCommand(session.getTransactionalEditingDomain()) {
+				   @Override
+				   protected void doExecute() {
+					   SubMonitor commandMonitor = SubMonitor.convert(subMonitor);
+					   session.addSemanticResource(model.eResource().getURI(), commandMonitor);
+				   }
+			   });
+		
+		Viewpoint workflowViewpoint = workflowViewpoint();
+		
+		ChangeViewpointSelectionCommand cc = new ChangeViewpointSelectionCommand(session, new ViewpointSelectionCallback(), new HashSet<>(asList(workflowViewpoint)), Collections.emptySet(), monitor);
+		session.getTransactionalEditingDomain().getCommandStack().execute(cc);
+		
+		session.getTransactionalEditingDomain().getCommandStack()
+			   .execute(new RecordingCommand(session.getTransactionalEditingDomain()) {
+					@Override
+					protected void doExecute() {
+						SubMonitor commandMonitor = SubMonitor.convert(subMonitor);
+						session.createView(workflowViewpoint, asList(model), true, commandMonitor);
+					}
+			   });
+	}
+
+	/**
+	 * Returns the 'EKumi Workflow' viewpoint.
+	 * 
+	 * @return the viewpoint defining representations for workflows
+	 * 
+	 * @throws CoreException if the viewpoint cannot be found
+	 */
+	private static Viewpoint workflowViewpoint() throws CoreException {
+		// Find the 'EKumi Workflow' viewpoint
+		Optional<Viewpoint> workflowViewpoint = EKumiViewpoints.workflow();
+		
+		if ( ! workflowViewpoint.isPresent()) {
+			Status error = new Status(IStatus.ERROR, "fr.kazejiyu.ekumi.ide.ui", "Cannot find EKumi's workflow editor viewpoint. Check that fr.kazejiyu.ekumi.specs.eds.design plug-in is available.");
+			throw new CoreException(error);
+		}
+		return workflowViewpoint.get();
+	}
+	
+	/**
+	 * Adds the Modeling nature to the given project, if it does not have it yet.
+	 * 
+	 * @param project
+	 * 			The project that requires the Modeling nature.
+	 * @param monitor
+	 * 			The instance monitoring the execution.
+	 * 
+	 * @throws CoreException if an error occurs while adding the nature
+	 */
+	private static void ensureHasModelingNature(IProject project, IProgressMonitor monitor) throws CoreException {
+		if (! ModelingProject.hasModelingProjectNature(project))
+			ModelingProjectManager.INSTANCE.convertToModelingProject(project, monitor);
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 				- generated source code,
 				- Exceptions,
 				- untestable activators -->
-		<sonar.exclusions>**/src-gen/**/*.*,**/*Exception.java,**/Activator.java,**/EKumiPlugin.java</sonar.exclusions>
+		<sonar.exclusions>**/src-gen/**/*.*,**/*Exception.java,**/Activator.java,**/EKumiPlugin.java,**/EKumiIdePlugin.java</sonar.exclusions>
 		<sonar.jacoco.reportPaths>../../tests/${project.artifactId}.test/target/jacoco.exec</sonar.jacoco.reportPaths>
 	</properties>
 


### PR DESCRIPTION
The `project_customization` extension point now have a `representations` attribute that can be used to specify a new `representation`.

Available representations are shown to the user in the `New Workflow Project` wizard ; one must be selected by the user in order to create the project. Selected representation has a chance to customize the project right after its creation in order to create new files or add specific project natures.

The current diagram editor is now provided through this extension point.